### PR TITLE
docs(cli): Add Sync CLI Skill documentation and sync to 0.0.15

### DIFF
--- a/.cursor/commands/sync-cli-skill.md
+++ b/.cursor/commands/sync-cli-skill.md
@@ -1,0 +1,177 @@
+# Sync CLI Skill
+
+Synchronize the `skills/base44-cli/` skill with the latest CLI source code from the Base44 CLI repository.
+
+## Usage
+
+When activated, this command will ask for:
+1. **CLI source folder path** (required) - The local path to the Base44 CLI source code
+2. **Documentation URL** (optional) - URL to fetch additional documentation
+
+## Steps
+
+### Step 1: Gather Input
+
+Ask the user for the required inputs using the AskQuestion tool if available, otherwise ask conversationally:
+
+**Required:**
+- CLI source folder path (e.g., `~/projects/base44-cli` or `/Users/me/base44-cli`)
+
+**Optional:**
+- Documentation URL (e.g., `https://docs.base44.com/cli`)
+
+If the user provided these in the initial prompt, use those values.
+
+### Step 2: Validate Source Folder
+
+1. Check that the provided path exists and contains CLI source code
+2. Look for these key indicators:
+   - `package.json` with CLI-related content
+   - `src/` or `commands/` directory
+   - Command implementation files (e.g., `login.ts`, `create.ts`, `deploy.ts`)
+
+If validation fails, ask the user to verify the path.
+
+### Step 3: Discover CLI Commands
+
+Scan the CLI source folder to find all available commands. Look for:
+
+1. **Command files** in directories like:
+   - `src/commands/`
+   - `commands/`
+   - `lib/commands/`
+
+2. **For each command, extract:**
+   - Command name and aliases
+   - Description/help text
+   - Available options and flags
+   - Usage examples (if present in source)
+   - Subcommands (e.g., `entities push`, `site deploy`)
+
+3. **Parse command definitions** from:
+   - Commander.js/yargs/oclif style command definitions
+   - Help strings and descriptions
+   - Option configurations
+
+### Step 4: Read Existing Skill
+
+Read the current skill files to understand what needs updating:
+
+```
+skills/base44-cli/
+├── SKILL.md
+└── references/
+    ├── auth-login.md
+    ├── auth-logout.md
+    ├── auth-whoami.md
+    ├── create.md
+    ├── deploy.md
+    ├── entities-create.md
+    ├── entities-push.md
+    ├── functions-create.md
+    ├── functions-deploy.md
+    ├── rls-examples.md
+    └── site-deploy.md
+```
+
+### Step 5: Compare and Identify Changes
+
+Compare discovered CLI commands with existing skill documentation:
+
+1. **New commands**: Commands in source but not in skill references
+2. **Updated commands**: Commands with changed options, descriptions, or behavior
+3. **Removed commands**: Commands in skill but not in source (verify before removing)
+4. **New options**: New flags or parameters added to existing commands
+
+Create a summary of changes to show the user before applying.
+
+### Step 6: Fetch External Documentation (Optional)
+
+If a documentation URL was provided:
+
+1. Fetch the documentation page
+2. Extract relevant command documentation
+3. Use this to supplement information from source code
+4. Cross-reference for accuracy
+
+### Step 7: Update Skill Files
+
+For each change identified:
+
+#### Update Reference Files
+
+For each command, update or create `references/{command-name}.md`:
+
+```markdown
+# base44 {command}
+
+{Description from source}
+
+## Syntax
+
+```bash
+npx base44 {command} [options]
+```
+
+## Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `-o, --option <value>` | {description} | {yes/no} |
+
+## Examples
+
+```bash
+{example usage from source or docs}
+```
+
+## Notes
+
+{Any important behavioral notes}
+```
+
+#### Update SKILL.md
+
+1. Update the **Available Commands** tables if commands changed
+2. Update **Quick Start** if workflow changed
+3. Update **Common Workflows** sections
+4. Keep the existing structure and formatting
+5. Do NOT change the frontmatter description unless explicitly asked
+
+### Step 8: Present Summary
+
+After updates, present a summary to the user:
+
+```
+## Sync Summary
+
+### Files Updated
+- references/new-command.md (created)
+- references/deploy.md (updated options)
+- SKILL.md (updated command table)
+
+### Changes Made
+- Added new command: `base44 new-command`
+- Updated `deploy` command: added `--force` flag
+- Removed deprecated `--legacy` option from `create`
+
+### Manual Review Recommended
+- [List any changes that need verification]
+```
+
+## Important Notes
+
+- **Preserve existing content**: Don't remove detailed explanations, examples, or warnings unless they're outdated
+- **Keep formatting consistent**: Match the existing style of SKILL.md and reference files
+- **Maintain progressive disclosure**: Keep detailed docs in references, summaries in SKILL.md
+- **Flag uncertainties**: If source code is unclear, flag it for manual review
+- **Respect RLS/FLS docs**: The `entities-create.md` and `rls-examples.md` contain hand-written security documentation - update carefully
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Can't find command files | Try searching for `.command(` or `program.command` patterns |
+| Options not detected | Look for `.option(` patterns in commander.js files |
+| Missing descriptions | Check for `description:` properties or `.description(` calls |
+| Subcommand structure | Commands like `entities push` may be in `entities/push.ts` |

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -164,9 +164,17 @@ npx base44 <command>
 
 ### Project Management
 
-| Command         | Description                                  | Reference                         |
-| --------------- | -------------------------------------------- | --------------------------------- |
-| `base44 create` | Create a new Base44 app (framework-agnostic) | [create.md](references/create.md) |
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `base44 create` | Create a new Base44 project from a template | [create.md](references/create.md) |
+| `base44 link` | Link an existing local project to Base44 | [link.md](references/link.md) |
+| `base44 dashboard` | Open the app dashboard in your browser | [dashboard.md](references/dashboard.md) |
+
+### Deployment
+
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `base44 deploy` | Deploy all resources (entities, functions, site) | [deploy.md](references/deploy.md) |
 
 ### Entity Management
 
@@ -234,15 +242,16 @@ For complete documentation, see [entities-create.md](references/entities-create.
    npx base44 create -n my-app -p .
    ```
 
-4. Push entities to Base44:
+4. Build and deploy everything:
    ```bash
-   npx base44 entities push
+   npm run build
+   npx base44 deploy -y
    ```
 
-5. Deploy your site:
-   ```bash
-   npx base44 site deploy -y
-   ```
+Or deploy individual resources:
+- `npx base44 entities push` - Push entities only
+- `npx base44 functions deploy` - Deploy functions only
+- `npx base44 site deploy -y` - Deploy site only
 
 ## Common Workflows
 
@@ -254,23 +263,41 @@ npx base44 login
 # Create project (ALWAYS use --name and --path flags)
 npx base44 create -n my-app -p .
 
-# Or create and deploy in one step
-npx base44 create -n my-app -p . --deploy
+# Or create with full-stack template and deploy in one step
+npx base44 create -n my-app -p ./my-app -t backend-and-client --deploy
 ```
 
-### Updating Entity Schema
+### Linking an Existing Project
 ```bash
-# After modifying entities in base44/entities/
-npx base44 entities push
+# If you have base44/config.jsonc but no .app.jsonc
+npx base44 link --create --name my-app
 ```
 
-### Deploying Changes
+### Deploying All Changes
 ```bash
-# Build your project first (using your framework's build command)
+# Build your project first
 npm run build
 
-# Deploy to Base44 (use -y to skip confirmation)
+# Deploy everything (entities, functions, and site)
+npx base44 deploy -y
+```
+
+### Deploying Individual Resources
+```bash
+# Push only entities
+npx base44 entities push
+
+# Deploy only functions
+npx base44 functions deploy
+
+# Deploy only site
 npx base44 site deploy -y
+```
+
+### Opening the Dashboard
+```bash
+# Open app dashboard in browser
+npx base44 dashboard
 ```
 
 ### Recommended package.json Scripts
@@ -283,7 +310,8 @@ Add these scripts to your `package.json` for easier CLI usage:
     "base44:login": "base44 login",
     "base44:push": "base44 entities push",
     "base44:functions": "base44 functions deploy",
-    "base44:deploy": "base44 site deploy -y",
+    "base44:site": "base44 site deploy -y",
+    "base44:deploy": "base44 deploy -y",
     "deploy": "npm run build && npm run base44:deploy"
   }
 }
@@ -293,7 +321,7 @@ Then use them like:
 ```bash
 npm run base44:login
 npm run base44:push
-npm run deploy  # Builds and deploys in one command
+npm run deploy  # Builds and deploys everything in one command
 ```
 
 ## Authentication

--- a/skills/base44-cli/references/create.md
+++ b/skills/base44-cli/references/create.md
@@ -1,6 +1,6 @@
 # base44 create
 
-Creates a new Base44 project. This command is framework-agnostic and does NOT initialize a local npm project.
+Creates a new Base44 project from a template. This command is framework-agnostic and can either scaffold a complete project or add Base44 configuration to an existing project.
 
 ## Critical: Non-Interactive Mode Required
 
@@ -18,14 +18,22 @@ npx base44 create --name <name> --path <path> [options]
 
 ## Options
 
-| Option                            | Description                                           | Required |
-| --------------------------------- | ----------------------------------------------------- | -------- |
-| `-n, --name <name>`               | Project name                                          | Yes*     |
-| `-p, --path <path>`               | Path where to create the project                      | Yes*     |
-| `-d, --description <description>` | Project description                                   | No       |
-| `--deploy`                        | Build and deploy the site (includes pushing entities) | No       |
+| Option | Description | Required |
+|--------|-------------|----------|
+| `-n, --name <name>` | Project name | Yes* |
+| `-p, --path <path>` | Path where to create the project | Yes* |
+| `-d, --description <description>` | Project description | No |
+| `-t, --template <id>` | Template ID (see templates below) | No |
+| `--deploy` | Build and deploy the site (includes pushing entities) | No |
 
 *Required for non-interactive mode. Both `--name` and `--path` must be provided together.
+
+## Templates
+
+| Template ID | Description |
+|-------------|-------------|
+| `backend-only` | Base44 configuration only (default) - use with existing frontend projects |
+| `backend-and-client` | Full-stack template with Vite + React + Tailwind + shadcn/ui |
 
 ## The `--path` Flag
 
@@ -47,8 +55,11 @@ npx base44 create --name <name> --path <path> [options]
 ## Examples
 
 ```bash
-# Create app in current directory
+# Create backend-only config in current directory (default template)
 npx base44 create -n my-app -p .
+
+# Create full-stack project with frontend template
+npx base44 create -n my-app -p ./my-app -t backend-and-client
 
 # Create app with description
 npx base44 create -n my-app -p . -d "My awesome app"
@@ -56,15 +67,17 @@ npx base44 create -n my-app -p . -d "My awesome app"
 # Create app and deploy immediately
 npx base44 create -n my-app -p . --deploy
 
-# Create app from existing Vite project
-npm create vite@latest my-react-app -- --template react
-npx base44 create -n my-app -p ./my-react-app --deploy
+# Create full-stack and deploy in one step
+npx base44 create -n my-app -p ./my-app -t backend-and-client --deploy
 ```
 
 ## What It Does
 
-1. Creates a `base44/` folder in your project with configuration files
-2. Registers the project with Base44 backend
-3. If `--deploy` is used:
+1. Applies the selected template to the target path
+2. Creates a `base44/` folder with configuration files
+3. Registers the project with Base44 backend
+4. Creates `base44/.app.jsonc` with the app ID
+5. If `--deploy` is used:
    - Pushes any entities defined in `base44/entities/`
-   - Builds and deploys the site (if site config exists)
+   - Runs install and build commands (for templates with frontend)
+   - Deploys the site to Base44 hosting

--- a/skills/base44-cli/references/dashboard.md
+++ b/skills/base44-cli/references/dashboard.md
@@ -1,0 +1,35 @@
+# base44 dashboard
+
+Opens the Base44 app dashboard in your default web browser.
+
+## Syntax
+
+```bash
+npx base44 dashboard
+```
+
+## Options
+
+This command has no options.
+
+## What It Does
+
+1. Reads the project's app ID from `base44/.app.jsonc`
+2. Opens the dashboard URL in your default browser
+
+## Example
+
+```bash
+# Open dashboard for current project
+npx base44 dashboard
+```
+
+## Requirements
+
+- Must be run from a linked Base44 project directory (contains `base44/.app.jsonc`)
+- Must be authenticated (run `npx base44 login` first)
+
+## Notes
+
+- The dashboard provides a web interface to manage your app's entities, functions, users, and settings
+- If you're not in a project directory, the command will fail with an error

--- a/skills/base44-cli/references/deploy.md
+++ b/skills/base44-cli/references/deploy.md
@@ -1,6 +1,6 @@
 # base44 deploy
 
-Deploys your Base44 app.
+Deploys all project resources (entities, functions, and site) to Base44 in a single command.
 
 ## Syntax
 
@@ -10,10 +10,74 @@ npx base44 deploy [options]
 
 ## Options
 
-| Option              | Description                   |
-| ------------------- | ----------------------------- |
-| `-p, --path <path>` | Path to the project to deploy |
+| Option | Description |
+|--------|-------------|
+| `-y, --yes` | Skip confirmation prompt |
+
+## What It Deploys
+
+The command automatically detects and deploys:
+
+1. **Entities** - All `.jsonc` files in `base44/entities/`
+2. **Functions** - All functions in `base44/functions/`
+3. **Site** - Built files from `site.outputDirectory` (if configured)
+
+## Examples
+
+```bash
+# Interactive mode - shows what will be deployed and asks for confirmation
+npx base44 deploy
+
+# Non-interactive - skip confirmation (for CI/CD or agent use)
+npx base44 deploy -y
+```
+
+## Typical Workflow
+
+```bash
+# 1. Make your changes (entities, functions, frontend code)
+
+# 2. Build the frontend (if you have one)
+npm run build
+
+# 3. Deploy everything
+npx base44 deploy -y
+```
+
+## What It Does
+
+1. Reads project configuration from `base44/config.jsonc`
+2. Detects available resources (entities, functions, site)
+3. Shows a summary of what will be deployed
+4. Asks for confirmation (unless `-y` flag is used)
+5. Deploys all resources in sequence:
+   - Pushes entity schemas
+   - Deploys functions
+   - Uploads site files
+6. Displays the dashboard URL and app URL (if site was deployed)
+
+## Requirements
+
+- Must be run from a linked Base44 project directory
+- Must be authenticated (run `npx base44 login` first)
+- For site deployment, must run `npm run build` first
+
+## Output
+
+After successful deployment:
+- **Dashboard**: Link to your app's management dashboard
+- **App URL**: Your deployed site's public URL (if site was included)
 
 ## Notes
 
-Details to be documented.
+- If no resources are found, the command exits with a message
+- Use individual commands (`entities push`, `functions deploy`, `site deploy`) if you only want to deploy specific resources
+- The site must be built before deployment - this command does not run `npm run build` for you
+
+## Related Commands
+
+| Command | Description |
+|---------|-------------|
+| `base44 entities push` | Push only entities |
+| `base44 functions deploy` | Deploy only functions |
+| `base44 site deploy` | Deploy only the site |

--- a/skills/base44-cli/references/link.md
+++ b/skills/base44-cli/references/link.md
@@ -1,0 +1,67 @@
+# base44 link
+
+Links an existing local Base44 project to a new Base44 app in the cloud. Use this when you have a `base44/config.jsonc` but haven't connected it to a Base44 app yet.
+
+## Critical: When to Use Link vs Create
+
+| Scenario | Command |
+|----------|---------|
+| Starting fresh, no `base44/` folder | `npx base44 create` |
+| Have `base44/config.jsonc` but no `.app.jsonc` | `npx base44 link` |
+| Project already linked (has `.app.jsonc`) | Already done, use `deploy` |
+
+## Syntax
+
+```bash
+npx base44 link [options]
+```
+
+## Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `-c, --create` | Create a new project (skip selection prompt) | No |
+| `-n, --name <name>` | Project name (required when `--create` is used) | With `--create` |
+| `-d, --description <description>` | Project description | No |
+
+## Non-Interactive Mode
+
+For CI/CD or agent use, provide `--create` with `--name`:
+
+```bash
+npx base44 link --create --name my-app
+```
+
+WRONG: `npx base44 link --create` (missing --name)
+RIGHT: `npx base44 link --create --name my-app`
+
+## Examples
+
+```bash
+# Interactive mode - prompts for project details
+npx base44 link
+
+# Non-interactive - create and link in one step
+npx base44 link --create --name my-app
+
+# With description
+npx base44 link --create --name my-app --description "My awesome app"
+```
+
+## What It Does
+
+1. Finds the `base44/config.jsonc` in the current directory (or parent directories)
+2. Verifies no `.app.jsonc` exists (project not already linked)
+3. Creates a new Base44 app in the cloud
+4. Writes the app ID to `base44/.app.jsonc`
+
+## Requirements
+
+- Must have `base44/config.jsonc` in the project
+- Must NOT have `base44/.app.jsonc` (use `deploy` if already linked)
+- Must be authenticated (run `npx base44 login` first)
+
+## Notes
+
+- After linking, you can deploy resources with `npx base44 deploy`
+- The `.app.jsonc` file should be git-ignored (contains your app ID)


### PR DESCRIPTION
- Introduced new documentation for the Sync CLI Skill, detailing the synchronization process with the Base44 CLI source code.
- Updated SKILL.md to include new command references and improved descriptions for existing commands.
- Added new reference files for `dashboard`, `link`, and updated `deploy` and `create` commands to clarify usage and options.
- Enhanced troubleshooting sections and provided examples for better user guidance.