### PR TITLE
Add TypeScript type definitions to SDK docs

### DIFF
--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -90,6 +90,8 @@ await base44.auth.loginViaEmailPassword("user@example.com", "password");
 
 For client setup and authentication modes, see [client.md](references/client.md).
 
+**TypeScript Support:** Each reference file includes a "Type Definitions" section with TypeScript interfaces and types for the module's methods, parameters, and return values.
+
 ## Installation
 
 Install the Base44 SDK:

--- a/skills/base44-sdk/references/analytics.md
+++ b/skills/base44-sdk/references/analytics.md
@@ -88,3 +88,26 @@ base44.analytics.track({
   eventName: "click"
 });
 ```
+
+## Type Definitions
+
+```typescript
+/** Properties that can be attached to a tracked event. */
+type TrackEventProperties = {
+  [key: string]: string | number | boolean | null | undefined;
+};
+
+/** Parameters for the track() method. */
+interface TrackEventParams {
+  /** The name of the event to track. */
+  eventName: string;
+  /** Optional properties to attach to the event. */
+  properties?: TrackEventProperties;
+}
+
+/** The analytics module interface. */
+interface AnalyticsModule {
+  /** Track a custom event with optional properties. */
+  track(params: TrackEventParams): void;
+}
+```

--- a/skills/base44-sdk/references/app-logs.md
+++ b/skills/base44-sdk/references/app-logs.md
@@ -62,3 +62,17 @@ function handleSettingsChange() {
 - Logs appear in the Analytics page of your app dashboard
 - App logs track page-level and feature-level activity
 - Use `analytics.track()` for custom events with properties, `appLogs.logUserInApp()` for simple page/feature tracking
+
+## Type Definitions
+
+```typescript
+/** App Logs module for tracking and analyzing app usage. */
+interface AppLogsModule {
+  /**
+   * Log user activity in the app.
+   * @param pageName - Name of the page or section being visited.
+   * @returns Promise that resolves when the log is recorded.
+   */
+  logUserInApp(pageName: string): Promise<void>;
+}
+```

--- a/skills/base44-sdk/references/base44-agents.md
+++ b/skills/base44-sdk/references/base44-agents.md
@@ -184,3 +184,179 @@ async function sendMessage(text) {
 // Cleanup on unmount
 return () => unsubscribe();
 ```
+
+## Type Definitions
+
+### AgentConversation
+
+```typescript
+/** An agent conversation containing messages exchanged with an AI agent. */
+interface AgentConversation {
+  /** Unique identifier for the conversation. */
+  id: string;
+  /** Application ID. */
+  app_id: string;
+  /** Name of the agent in this conversation. */
+  agent_name: string;
+  /** ID of the user who created the conversation. */
+  created_by_id: string;
+  /** When the conversation was created. */
+  created_date: string;
+  /** When the conversation was last updated. */
+  updated_date: string;
+  /** Array of messages in the conversation. */
+  messages: AgentMessage[];
+  /** Optional metadata associated with the conversation. */
+  metadata?: Record<string, any>;
+}
+```
+
+### AgentMessage
+
+```typescript
+/** A message in an agent conversation. */
+interface AgentMessage {
+  /** Unique identifier for the message. */
+  id: string;
+  /** Role of the message sender. */
+  role: "user" | "assistant" | "system";
+  /** When the message was created. */
+  created_date: string;
+  /** When the message was last updated. */
+  updated_date: string;
+  /** Message content. */
+  content?: string | Record<string, any>;
+  /** Optional reasoning information for the message. */
+  reasoning?: AgentMessageReasoning | null;
+  /** URLs to files attached to the message. */
+  file_urls?: string[];
+  /** Tool calls made by the agent. */
+  tool_calls?: AgentMessageToolCall[];
+  /** Token usage statistics. */
+  usage?: AgentMessageUsage;
+  /** Whether the message is hidden from the user. */
+  hidden?: boolean;
+  /** Custom context provided with the message. */
+  custom_context?: AgentMessageCustomContext[];
+  /** Model used to generate the message. */
+  model?: string;
+  /** Checkpoint ID for the message. */
+  checkpoint_id?: string;
+  /** Metadata about when and by whom the message was created. */
+  metadata?: AgentMessageMetadata;
+}
+```
+
+### Supporting Types
+
+```typescript
+/** Reasoning information for an agent message. */
+interface AgentMessageReasoning {
+  /** When reasoning started. */
+  start_date: string;
+  /** When reasoning ended. */
+  end_date?: string;
+  /** Reasoning content. */
+  content: string;
+}
+
+/** A tool call made by the agent. */
+interface AgentMessageToolCall {
+  /** Tool call ID. */
+  id: string;
+  /** Name of the tool called. */
+  name: string;
+  /** Arguments passed to the tool as JSON string. */
+  arguments_string: string;
+  /** Status of the tool call. */
+  status: "running" | "success" | "error" | "stopped";
+  /** Results from the tool call. */
+  results?: string;
+}
+
+/** Token usage statistics for an agent message. */
+interface AgentMessageUsage {
+  /** Number of tokens in the prompt. */
+  prompt_tokens?: number;
+  /** Number of tokens in the completion. */
+  completion_tokens?: number;
+}
+
+/** Custom context provided with an agent message. */
+interface AgentMessageCustomContext {
+  /** Context message. */
+  message: string;
+  /** Associated data for the context. */
+  data: Record<string, any>;
+  /** Type of context. */
+  type: string;
+}
+
+/** Metadata about when and by whom a message was created. */
+interface AgentMessageMetadata {
+  /** When the message was created. */
+  created_date: string;
+  /** Email of the user who created the message. */
+  created_by_email: string;
+  /** Full name of the user who created the message. */
+  created_by_full_name: string;
+}
+```
+
+### CreateConversationParams
+
+```typescript
+/** Parameters for creating a new conversation. */
+interface CreateConversationParams {
+  /** The name of the agent to create a conversation with. */
+  agent_name: string;
+  /** Optional metadata to attach to the conversation. */
+  metadata?: Record<string, any>;
+}
+```
+
+### ModelFilterParams
+
+```typescript
+/** Parameters for filtering, sorting, and paginating conversations. */
+interface ModelFilterParams {
+  /** Query object with field-value pairs for filtering. */
+  q?: Record<string, any>;
+  /** Sort parameter (e.g., "-created_date" for descending). */
+  sort?: string | null;
+  /** Maximum number of results to return. */
+  limit?: number | null;
+  /** Number of results to skip for pagination. */
+  skip?: number | null;
+  /** Array of field names to include in the response. */
+  fields?: string[] | null;
+}
+```
+
+### AgentsModule
+
+```typescript
+/** Agents module for managing AI agent conversations. */
+interface AgentsModule {
+  /** Gets all conversations from all agents in the app. */
+  getConversations(): Promise<AgentConversation[]>;
+
+  /** Gets a specific conversation by ID. */
+  getConversation(conversationId: string): Promise<AgentConversation | undefined>;
+
+  /** Lists conversations with filtering, sorting, and pagination. */
+  listConversations(filterParams: ModelFilterParams): Promise<AgentConversation[]>;
+
+  /** Creates a new conversation with an agent. */
+  createConversation(conversation: CreateConversationParams): Promise<AgentConversation>;
+
+  /** Adds a message to a conversation. */
+  addMessage(conversation: AgentConversation, message: Partial<AgentMessage>): Promise<AgentMessage>;
+
+  /** Subscribes to real-time updates for a conversation. Returns unsubscribe function. */
+  subscribeToConversation(conversationId: string, onUpdate?: (conversation: AgentConversation) => void): () => void;
+
+  /** Gets WhatsApp connection URL for an agent. */
+  getWhatsAppConnectURL(agentName: string): string;
+}
+```

--- a/skills/base44-sdk/references/client.md
+++ b/skills/base44-sdk/references/client.md
@@ -192,3 +192,66 @@ createClient({
 **⚠️ Critical:**
 - The parameter name is `appId`, not `clientId` or `id`. Using the wrong parameter name will cause errors.
 - The `onError` handler must be nested inside the `options` object, not at the top level.
+
+## Type Definitions
+
+### CreateClientConfig
+
+```typescript
+/** Configuration for creating a Base44 client. */
+interface CreateClientConfig {
+  /** The Base44 app ID (required). */
+  appId: string;
+  /** User authentication token. Used to authenticate as a specific user. */
+  token?: string;
+  /** Service role authentication token (backend only). */
+  serviceToken?: string;
+  /** Additional client options. */
+  options?: CreateClientOptions;
+}
+
+/** Options for creating a Base44 client. */
+interface CreateClientOptions {
+  /** Optional error handler called whenever an API error occurs. */
+  onError?: (error: Error) => void;
+}
+```
+
+### Base44Client
+
+```typescript
+/** The Base44 client instance. */
+interface Base44Client {
+  /** Entities module for CRUD operations on your data models. */
+  entities: EntitiesModule;
+  /** Integrations module for calling pre-built integration endpoints. */
+  integrations: IntegrationsModule;
+  /** Auth module for user authentication and management. */
+  auth: AuthModule;
+  /** Functions module for invoking custom backend functions. */
+  functions: FunctionsModule;
+  /** Agents module for managing AI agent conversations. */
+  agents: AgentsModule;
+  /** App logs module for tracking app usage. */
+  appLogs: AppLogsModule;
+  /** Analytics module for tracking custom events. */
+  analytics: AnalyticsModule;
+
+  /** Cleanup function to disconnect WebSocket connections. */
+  cleanup(): void;
+
+  /** Sets a new authentication token for all subsequent requests. */
+  setToken(newToken: string): void;
+
+  /** Provides access to modules with elevated service role permissions (backend only). */
+  readonly asServiceRole: {
+    entities: EntitiesModule;
+    integrations: IntegrationsModule;
+    connectors: ConnectorsModule;
+    functions: FunctionsModule;
+    agents: AgentsModule;
+    appLogs: AppLogsModule;
+    cleanup(): void;
+  };
+}
+```

--- a/skills/base44-sdk/references/connectors.md
+++ b/skills/base44-sdk/references/connectors.md
@@ -91,3 +91,23 @@ Deno.serve(async (req) => {
 - **Service role required**: Must use `base44.asServiceRole.connectors`
 - **You handle the API calls**: Base44 only provides the token; you make the actual API requests
 - **Token refresh**: Base44 handles token refresh automatically
+
+## Type Definitions
+
+```typescript
+/**
+ * The type of external integration/connector.
+ * Examples: 'googlecalendar', 'slack', 'github', 'notion', etc.
+ */
+type ConnectorIntegrationType = string;
+
+/** Connectors module for managing OAuth tokens for external services. */
+interface ConnectorsModule {
+  /**
+   * Retrieves an OAuth access token for a specific external integration type.
+   * @param integrationType - The type of integration (e.g., 'googlecalendar', 'slack').
+   * @returns Promise resolving to the access token string.
+   */
+  getAccessToken(integrationType: ConnectorIntegrationType): Promise<string>;
+}
+```

--- a/skills/base44-sdk/references/entities.md
+++ b/skills/base44-sdk/references/entities.md
@@ -177,3 +177,77 @@ Operations succeed or fail based on these rules - no partial results.
 RLS and FLS are configured in entity schema files (`base44/entities/*.jsonc`). See [entities-create.md](../../base44-cli/references/entities-create.md#row-level-security-rls) for configuration details.
 
 **Note:** `asServiceRole` sets the user's role to `"admin"` but does NOT bypass RLS. Your RLS rules must include admin access (e.g., `{ "user_condition": { "role": "admin" } }`) for service role operations to succeed.
+
+## Type Definitions
+
+### RealtimeEvent
+
+```typescript
+/** Event types for realtime entity updates. */
+type RealtimeEventType = "create" | "update" | "delete";
+
+/** Payload received when a realtime event occurs. */
+interface RealtimeEvent {
+  /** The type of change that occurred. */
+  type: RealtimeEventType;
+  /** The entity data. */
+  data: any;
+  /** The unique identifier of the affected entity. */
+  id: string;
+  /** ISO 8601 timestamp of when the event occurred. */
+  timestamp: string;
+}
+
+/** Callback function invoked when a realtime event occurs. */
+type RealtimeCallback = (event: RealtimeEvent) => void;
+
+/** Function returned from subscribe, call it to unsubscribe. */
+type Subscription = () => void;
+```
+
+### EntityHandler
+
+```typescript
+/** Entity handler providing CRUD operations for a specific entity type. */
+interface EntityHandler {
+  /** Lists records with optional pagination and sorting. */
+  list(sort?: string, limit?: number, skip?: number, fields?: string[]): Promise<any>;
+
+  /** Filters records based on a query. */
+  filter(query: Record<string, any>, sort?: string, limit?: number, skip?: number, fields?: string[]): Promise<any>;
+
+  /** Gets a single record by ID. */
+  get(id: string): Promise<any>;
+
+  /** Creates a new record. */
+  create(data: Record<string, any>): Promise<any>;
+
+  /** Updates an existing record. */
+  update(id: string, data: Record<string, any>): Promise<any>;
+
+  /** Deletes a single record by ID. */
+  delete(id: string): Promise<any>;
+
+  /** Deletes multiple records matching a query. */
+  deleteMany(query: Record<string, any>): Promise<any>;
+
+  /** Creates multiple records in a single request. */
+  bulkCreate(data: Record<string, any>[]): Promise<any>;
+
+  /** Imports records from a file (frontend only). */
+  importEntities(file: File): Promise<any>;
+
+  /** Subscribes to realtime updates. Returns unsubscribe function. */
+  subscribe(callback: RealtimeCallback): Subscription;
+}
+```
+
+### EntitiesModule
+
+```typescript
+/** Entities module for managing app data. */
+interface EntitiesModule {
+  /** Access any entity by name dynamically. */
+  [entityName: string]: EntityHandler;
+}
+```

--- a/skills/base44-sdk/references/functions.md
+++ b/skills/base44-sdk/references/functions.md
@@ -159,3 +159,22 @@ Deno.serve(async (req) => {
 | Service Role | `base44.asServiceRole.functions.invoke()` | Admin-level access |
 
 Inside the function, use `createClientFromRequest(req)` to get a client that inherits the caller's auth context.
+
+## Type Definitions
+
+```typescript
+/** Functions module for invoking custom backend functions. */
+interface FunctionsModule {
+  /**
+   * Invokes a custom backend function by name.
+   *
+   * If any parameter is a File object, the request will automatically be
+   * sent as multipart/form-data. Otherwise, it will be sent as JSON.
+   *
+   * @param functionName - The name of the function to invoke.
+   * @param data - An object containing named parameters for the function.
+   * @returns Promise resolving to the function's response.
+   */
+  invoke(functionName: string, data: Record<string, any>): Promise<any>;
+}
+```

--- a/skills/base44-sdk/references/integrations.md
+++ b/skills/base44-sdk/references/integrations.md
@@ -221,3 +221,157 @@ const response = await base44.integrations.custom.call(
 
 - **Core integrations**: Available on all plans
 - **Catalog/Custom integrations**: Require Builder plan or higher
+
+## Type Definitions
+
+### Core Integration Parameters
+
+```typescript
+/** Parameters for the InvokeLLM function. */
+interface InvokeLLMParams {
+  /** The prompt text to send to the model. */
+  prompt: string;
+  /** If true, uses Google Search/Maps/News for real-time context. */
+  add_context_from_internet?: boolean;
+  /** JSON schema for structured output. If provided, returns object instead of string. */
+  response_json_schema?: object;
+  /** File URLs (from UploadFile) to provide as context. */
+  file_urls?: string[];
+}
+
+/** Parameters for the GenerateImage function. */
+interface GenerateImageParams {
+  /** Description of the image to generate. */
+  prompt: string;
+}
+
+/** Result from GenerateImage. */
+interface GenerateImageResult {
+  /** URL of the generated image. */
+  url: string;
+}
+
+/** Parameters for the UploadFile function. */
+interface UploadFileParams {
+  /** The file object to upload. */
+  file: File;
+}
+
+/** Result from UploadFile. */
+interface UploadFileResult {
+  /** URL of the uploaded file. */
+  file_url: string;
+}
+
+/** Parameters for the SendEmail function. */
+interface SendEmailParams {
+  /** Recipient email address. */
+  to: string;
+  /** Email subject line. */
+  subject: string;
+  /** Plain text or HTML email body. */
+  body: string;
+  /** Sender name (defaults to app name). */
+  from_name?: string;
+}
+
+/** Parameters for ExtractDataFromUploadedFile. */
+interface ExtractDataFromUploadedFileParams {
+  /** URL of the uploaded file. */
+  file_url: string;
+  /** JSON schema defining fields to extract. */
+  json_schema: object;
+}
+
+/** Parameters for UploadPrivateFile. */
+interface UploadPrivateFileParams {
+  /** The file object to upload. */
+  file: File;
+}
+
+/** Result from UploadPrivateFile. */
+interface UploadPrivateFileResult {
+  /** URI of the private file (used for signed URLs). */
+  file_uri: string;
+}
+
+/** Parameters for CreateFileSignedUrl. */
+interface CreateFileSignedUrlParams {
+  /** URI from UploadPrivateFile. */
+  file_uri: string;
+  /** Expiration time in seconds (default: 300). */
+  expires_in?: number;
+}
+
+/** Result from CreateFileSignedUrl. */
+interface CreateFileSignedUrlResult {
+  /** Temporary signed URL to access the file. */
+  signed_url: string;
+}
+```
+
+### CoreIntegrations
+
+```typescript
+/** Core package containing built-in Base44 integration functions. */
+interface CoreIntegrations {
+  InvokeLLM(params: InvokeLLMParams): Promise<string | object>;
+  GenerateImage(params: GenerateImageParams): Promise<GenerateImageResult>;
+  UploadFile(params: UploadFileParams): Promise<UploadFileResult>;
+  SendEmail(params: SendEmailParams): Promise<any>;
+  ExtractDataFromUploadedFile(params: ExtractDataFromUploadedFileParams): Promise<object>;
+  UploadPrivateFile(params: UploadPrivateFileParams): Promise<UploadPrivateFileResult>;
+  CreateFileSignedUrl(params: CreateFileSignedUrlParams): Promise<CreateFileSignedUrlResult>;
+}
+```
+
+### Custom Integrations
+
+```typescript
+/** Parameters for calling a custom integration endpoint. */
+interface CustomIntegrationCallParams {
+  /** Request body payload. */
+  payload?: Record<string, any>;
+  /** Path parameters to substitute in the URL. */
+  pathParams?: Record<string, string>;
+  /** Query string parameters. */
+  queryParams?: Record<string, any>;
+  /** Additional headers for this request. */
+  headers?: Record<string, string>;
+}
+
+/** Response from a custom integration call. */
+interface CustomIntegrationCallResponse {
+  /** Whether the external API returned a 2xx status code. */
+  success: boolean;
+  /** The HTTP status code from the external API. */
+  status_code: number;
+  /** The response data from the external API. */
+  data: any;
+}
+
+/** Module for calling custom workspace-level API integrations. */
+interface CustomIntegrationsModule {
+  /**
+   * Call a custom integration endpoint.
+   * @param slug - The integration's unique identifier.
+   * @param operationId - The operation ID from the OpenAPI spec.
+   * @param params - Optional payload, pathParams, queryParams, headers.
+   */
+  call(slug: string, operationId: string, params?: CustomIntegrationCallParams): Promise<CustomIntegrationCallResponse>;
+}
+```
+
+### IntegrationsModule
+
+```typescript
+/** Integrations module for calling integration endpoints. */
+type IntegrationsModule = {
+  /** Core package with built-in integrations. */
+  Core: CoreIntegrations;
+  /** Custom integrations module. */
+  custom: CustomIntegrationsModule;
+  /** Additional integration packages (dynamic). */
+  [packageName: string]: any;
+};
+```

--- a/skills/base44-sdk/references/users.md
+++ b/skills/base44-sdk/references/users.md
@@ -64,3 +64,19 @@ The `role` parameter must be one of:
 await base44.users.inviteUser("newuser@example.com", "user");
 await base44.auth.inviteUser("newuser@example.com", "user");
 ```
+
+## Type Definitions
+
+```typescript
+/** Users module for inviting users to the app. */
+interface UsersModule {
+  /**
+   * Invite a user to the application.
+   * @param user_email - User's email address.
+   * @param role - User's role ('user' or 'admin').
+   * @returns Promise resolving when the invitation is sent.
+   * @throws Error if role is not 'user' or 'admin'.
+   */
+  inviteUser(user_email: string, role: "user" | "admin"): Promise<any>;
+}
+```


### PR DESCRIPTION
## Summary
- Add TypeScript type definitions across all SDK reference docs
- Improves developer experience with explicit types for API parameters and responses

## Test plan
- Review documentation changes for accuracy