### PR TITLE
Enhance documentation for base44 create command in SKILL.md and create.md

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -168,7 +168,7 @@ npx base44 <command>
 
 | Command | Description | Reference |
 |---------|-------------|-----------|
-| `base44 create` | Create a new Base44 project from a template | [create.md](references/create.md) |
+| `base44 create` | Create a new Base44 project from a template | [create.md](references/create.md) ⚠️ **MUST READ** |
 | `base44 link` | Link an existing local project to Base44 | [link.md](references/link.md) |
 | `base44 dashboard` | Open the app dashboard in your browser | [dashboard.md](references/dashboard.md) |
 
@@ -257,17 +257,14 @@ Or deploy individual resources:
 
 ## Common Workflows
 
-### Starting a New Project
-```bash
-# Login first
-npx base44 login
+### Creating a New Project
 
-# Create project (ALWAYS provide name and --path flag)
-npx base44 create my-app -p .
+**⚠️ MANDATORY: Before running `base44 create`, you MUST read [create.md](references/create.md) for:**
+- **Template selection** - Choose the correct template (`backend-and-client` vs `backend-only`)
+- **Correct workflow** - Different templates require different setup steps
+- **Common pitfalls** - Avoid folder creation errors that cause failures
 
-# Or create with full-stack template and deploy in one step
-npx base44 create my-app -p ./my-app -t backend-and-client --deploy
-```
+Failure to follow the create.md instructions will result in broken project scaffolding.
 
 ### Linking an Existing Project
 ```bash

--- a/skills/base44-cli/references/create.md
+++ b/skills/base44-cli/references/create.md
@@ -28,44 +28,72 @@ npx base44 create [name] --path <path> [options]
 
 *Required for non-interactive mode. Both `name` and `--path` must be provided together.
 
-## Templates
+## Template Selection (CRITICAL - Choose Appropriately)
 
-| Template ID | Description |
-|-------------|-------------|
-| `backend-only` | Base44 configuration only (default) - use with existing frontend projects |
-| `backend-and-client` | Full-stack template with Vite + React + Tailwind + shadcn/ui |
+**You MUST select the most appropriate template based on user requirements:**
+
+| Template ID | When to Use | Example Scenarios |
+|-------------|-------------|-------------------|
+| `backend-and-client` | Creating a NEW full-stack web app from scratch | "Create a task app", "Build me a dashboard", "Make a SaaS app" |
+| `backend-only` | Adding Base44 to an EXISTING project OR using a different framework (Next.js, Vue, Svelte, etc.) | "Add Base44 to my project", "I want to use Next.js", "I already have a frontend" |
+
+**Default Choice:** When the user asks to "create an app" or "build a project" without specifying a particular framework, use `backend-and-client` to provide a complete, production-ready application with Vite + React + Tailwind + shadcn/ui.
 
 ## The `--path` Flag
 
-- **For existing projects:** Use `-p .` to use current directory
+- **For `backend-and-client` template (new projects):** Use a new subfolder path
   ```bash
-  npx base44 create -n my-app -p .
+  npx base44 create my-app -p ./my-app -t backend-and-client
   ```
-- **For new projects:** Point to where project files exist
+- **For `backend-only` template (existing projects):** Use `-p .` in the current directory
   ```bash
-  # Example: After Vite creates a subfolder
-  npm create vite@latest my-react-app -- --template react
-  npx base44 create -n my-app -p ./my-react-app
+  npx base44 create my-app -p .
   ```
-- **Custom location:**
-  ```bash
-  npx base44 create -n my-app -p /path/to/project
-  ```
+
+## Workflow: Using `backend-only` with External Frameworks
+
+**CRITICAL: The project folder MUST exist BEFORE running `base44 create` with `backend-only`**
+
+The `backend-only` template only adds Base44 configuration files - it does NOT create a frontend. If you need a frontend with a specific framework:
+
+```bash
+# Step 1: Initialize the frontend project FIRST
+npm create vite@latest my-app -- --template react  # or vue, svelte, etc.
+# OR: npx create-next-app@latest my-app
+# OR: any other framework's init command
+
+# Step 2: Navigate into the created folder
+cd my-app
+
+# Step 3: Install Base44 CLI
+npm install --save-dev base44
+
+# Step 4: Add Base44 configuration
+npx base44 create my-app -p .
+```
+
+**WARNING:** Do NOT:
+- Create an empty folder manually, then try to run `npx create vite` inside it (will fail - folder exists)
+- Run `base44 create` with `backend-only` expecting it to create a frontend (it won't)
+
+**DO:**
+- Run the external framework's init command FIRST (it creates its own folder)
+- Then run `base44 create` inside that folder with `-p .`
 
 ## Examples
 
 ```bash
-# Create backend-only config in current directory (default template)
-npx base44 create my-app -p .
-
-# Create full-stack project with frontend template
+# RECOMMENDED: Create full-stack project (for new apps)
 npx base44 create my-app -p ./my-app -t backend-and-client
-
-# Create app and deploy immediately
-npx base44 create my-app -p . --deploy
 
 # Create full-stack and deploy in one step
 npx base44 create my-app -p ./my-app -t backend-and-client --deploy
+
+# Add Base44 to EXISTING project (must be inside the project folder)
+npx base44 create my-app -p .
+
+# Add Base44 to existing project and deploy
+npx base44 create my-app -p . --deploy
 
 # Create without adding AI agent skills
 npx base44 create my-app -p . --skills=false


### PR DESCRIPTION

- Added critical warnings and mandatory reading notes for the `base44 create` command to ensure users follow the correct workflow and template selection.
- Updated template selection section in create.md to clarify when to use `backend-only` vs `backend-and-client`.
- Improved examples and added critical steps for using the `backend-only` template with existing frameworks.
- Emphasized the importance of following instructions to avoid project scaffolding issues.