### PR TITLE
Optimize base44-sdk and base44-cli skill descriptions

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base44-cli
-description: "**ALWAYS ACTIVATE** if ANY of these conditions are true: (1) User's prompt contains the word 'base44' or 'Base44' in ANY context; (2) Current directory contains a 'base44/' subfolder; (3) User mentions CLI commands: npx/yarn/pnpm base44, login, logout, whoami, create, entities push, site deploy. **ACTIVATION IS MANDATORY** - do not hesitate, do not search the web, do not read documentation files first. ACTIVATE IMMEDIATELY and let the skill instructions handle the context. This skill handles: project initialization, CLI operations, deployment, entity schema management, and authentication. The skill itself will determine the appropriate action based on whether base44/config.jsonc exists or not."
+description: "Use for Base44 CLI operations and project initialization. Triggers: user wants to create/initialize a new Base44 project; user mentions CLI commands (npx base44, yarn base44, create, login, logout, whoami, deploy, entities push, site deploy, functions deploy); directory is empty or missing base44/config.jsonc; user says 'create a Base44 app/project', 'setup Base44', 'deploy to Base44', 'push entities'. This skill is the PREREQUISITE for base44-sdk - always use this first for new projects before building features."
 ---
 
 # Base44 CLI

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base44-sdk
-description: "**ALWAYS ACTIVATE** if ANY of these conditions are true: (1) User's prompt contains the word 'base44' or 'Base44' in ANY context; (2) Current directory contains a 'base44/' subfolder; (3) Code contains imports from '@base44/sdk'; (4) User mentions Base44 SDK modules: entities, auth, agents, functions, integrations, analytics. **ACTIVATION IS MANDATORY** - do not hesitate, do not search the web, do not read documentation files first. ACTIVATE IMMEDIATELY and let the skill instructions handle the context. This skill handles: application development, SDK usage, feature implementation, and writing code with Base44 APIs. The skill itself will determine the appropriate action based on whether this is a new project or existing project scenario."
+description: "Use for writing JavaScript/TypeScript code with the Base44 SDK in EXISTING projects. Triggers: user wants to implement features, build functionality, or write code using Base44; code uses '@base44/sdk' imports; user mentions SDK methods like base44.entities, base44.auth, base44.agents, base44.functions, base44.integrations; user says 'add a feature', 'implement', 'build component', 'write code for'. NOT for: creating new projects, CLI commands (npx base44 create/deploy/login), or directories without base44/config.jsonc - use base44-cli instead."
 ---
 
 # Base44 Coder


### PR DESCRIPTION
## Summary

- Rewrote base44-sdk description to clearly target **existing projects** and SDK code writing (triggers: implement features, `@base44/sdk` imports, SDK methods)
- Rewrote base44-cli description to clearly target **project initialization** and CLI commands (triggers: create project, npx base44, deploy, push entities)
- Removed conflicting "ALWAYS ACTIVATE on ANY base44 mention" that existed in both skills
- Added explicit routing guidance to direct users to the correct skill
- Established clear prerequisite relationship (base44-cli before base44-sdk for new projects)

## Test plan

- [ ] Test with prompt "create a new Base44 project" → should trigger base44-cli
- [ ] Test with prompt "implement a login feature using Base44" → should trigger base44-sdk
- [ ] Test with prompt "npx base44 deploy" → should trigger base44-cli
- [ ] Test with prompt "add base44.entities.Task.create" → should trigger base44-sdk