### PR TITLE
docs: Reflect `add-skill` CLI rename to `skills`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Work-in-progress skills that are:
 
 ```bash
 # From the repo root
-npx add-skill . --skill your-skill-name -a cursor
+npx skills add . --skill your-skill-name -a cursor
 ```
 
 2. Verify the skill loads in your agent

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 
 Install these skills so your coding agents can assist with [Base44](https://docs.base44.com/) development.
 
-Supports [many AI coding agents](https://github.com/vercel-labs/add-skill#available-agents), including Cursor, Claude Code, Codex, and OpenCode.
+Supports [many AI coding agents](https://github.com/vercel-labs/skills#available-agents), including Cursor, Claude Code, Codex, and OpenCode.
 
 ## Installation
 
-Install skills using [`add-skill`](https://github.com/vercel-labs/add-skill):
+Install skills using [`skills`](https://github.com/vercel-labs/skills):
 
 ```bash
 # Install all skills
-npx add-skill base44/skills
+npx skills add base44/skills
 
 # Install globally (user-level)
-npx add-skill base44/skills -g
+npx skills add base44/skills -g
 ```
 
 ## Available skills


### PR DESCRIPTION
The `add-skill` CLI tool has been renamed to `skills`. Updated all references and command examples in `README.md` and `CONTRIBUTING.md` to use the new `skills` command.

Specifically:
* `npx add-skill` commands are now `npx skills add`