### PR TITLE
Update sync-cli-skill workflow to allow base44-github-actions[bot]

### DIFF
--- a/.github/workflows/sync-cli-skill.yml
+++ b/.github/workflows/sync-cli-skill.yml
@@ -33,6 +33,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'base44-github-actions[bot]'
           claude_args: '--allowedTools "Edit,Write,MultiEdit,Bash(git:*),Bash(gh pr:*),Bash(mkdir:*)"'
           prompt: |
             /sync-cli-skill


### PR DESCRIPTION
Added 'allowed_bots' parameter to the sync-cli-skill workflow to enable the base44-github-actions[bot] for enhanced automation capabilities.