### PR TITLE
docs: add validation requirements for agent tool configs

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -258,8 +258,8 @@ Agents are conversational AI assistants that can interact with users, access you
 **Naming rules:** Agent names must be lowercase alphanumeric with underscores only (e.g., `support_agent`, `order_bot`)
 
 **Tool config types:**
-- **Entity tools**: `entity_name` + `allowed_operations` (array of: `read`, `create`, `update`, `delete`)
-- **Backend function tools**: `function_name` + `description`
+- **Entity tools**: `entity_name` (MUST reference an existing entity in `base44/entities/`) + `allowed_operations` (array of: `read`, `create`, `update`, `delete`)
+- **Backend function tools**: `function_name` (MUST reference an existing function in `base44/functions/`) + `description`
 
 ### Site Deployment
 

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -258,8 +258,8 @@ Agents are conversational AI assistants that can interact with users, access you
 **Naming rules:** Agent names must be lowercase alphanumeric with underscores only (e.g., `support_agent`, `order_bot`)
 
 **Tool config types:**
-- **Entity tools**: `entity_name` (MUST reference an existing entity in `base44/entities/`) + `allowed_operations` (array of: `read`, `create`, `update`, `delete`)
-- **Backend function tools**: `function_name` (MUST reference an existing function in `base44/functions/`) + `description`
+- **Entity tools**: `entity_name` (MUST reference an existing `name` field of an entity configuration defined in `base44/entities/`) + `allowed_operations` (array of: `read`, `create`, `update`, `delete`)
+- **Backend function tools**: `function_name` (MUST reference an existing `name` of a backend function configuration defined in `base44/functions/`) + `description`
 
 ### Site Deployment
 

--- a/skills/base44-cli/references/agents-push.md
+++ b/skills/base44-cli/references/agents-push.md
@@ -88,6 +88,11 @@ Each agent file should be a `.jsonc` file in `base44/agents/` with this structur
 - Valid: `support_agent`, `order_bot`, `task_helper`
 - Invalid: `Support-Agent`, `OrderBot`, `task helper`
 
+**Tool configuration validation:**
+- **Entity tools**: The `entity_name` MUST reference an existing entity defined in `base44/entities/`
+- **Backend function tools**: The `function_name` MUST reference an existing backend function defined in `base44/functions/`
+- **Allowed operations**: Must be one or more of: `read`, `create`, `update`, `delete`
+
 ## Use Cases
 
 - After defining new agents in your project

--- a/skills/base44-cli/references/agents-push.md
+++ b/skills/base44-cli/references/agents-push.md
@@ -89,8 +89,8 @@ Each agent file should be a `.jsonc` file in `base44/agents/` with this structur
 - Invalid: `Support-Agent`, `OrderBot`, `task helper`
 
 **Tool configuration validation:**
-- **Entity tools**: The `entity_name` MUST reference an existing entity defined in `base44/entities/`
-- **Backend function tools**: The `function_name` MUST reference an existing backend function defined in `base44/functions/`
+- **Entity tools**: The `entity_name` MUST reference an existing `name` field of an entity configuration defined in `base44/entities/`
+- **Backend function tools**: The `function_name` MUST reference an existing `name` of a backend function configuration defined in `base44/functions/`
 - **Allowed operations**: Must be one or more of: `read`, `create`, `update`, `delete`
 
 ## Use Cases


### PR DESCRIPTION
Updated agent management skills documentation to clarify validation requirements:

- Entity tools MUST reference existing entities in `base44/entities/`
- Backend function tools MUST reference existing backend functions in `base44/functions/`
- Allowed operations must be one or more of: `read`, `create`, `update`, `delete`

Closes #49

Generated with [Claude Code](https://claude.ai/code)