### PR TITLE
Discourage redirectToLogin in favor of custom login UI

### DIFF
--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -238,7 +238,8 @@ const pendingTasks = await base44.entities.Task.filter(
 ```javascript
 const user = await base44.auth.me();
 if (!user) {
-  base44.auth.redirectToLogin(window.location.href);
+  // Navigate to your custom login page
+  navigate('/login', { state: { returnTo: window.location.pathname } });
   return;
 }
 ```

--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -13,7 +13,7 @@ me() → Promise<User | null>
 updateMe(data) → Promise<User>
 isAuthenticated() → Promise<boolean>
 logout(redirectUrl?) → void
-redirectToLogin(nextUrl) → void
+redirectToLogin(nextUrl) → void              # ⚠️ Avoid - prefer custom login UI
 register({email, password, turnstile_token?, referral_code?}) → Promise<any>
 verifyOtp({email, otpCode}) → Promise<any>
 resendOtp(email) → Promise<any>


### PR DESCRIPTION
Update SDK documentation to recommend building custom login UI using
loginViaEmailPassword() and loginWithProvider() instead of redirectToLogin() so local login will work.

Changes:
- Add deprecation warning to redirectToLogin in method reference table
- Update Protected Route Pattern to use navigate() instead of redirectToLogin
- Update error handling examples to navigate to custom login page
- Reframe "Limitations" section as "Authentication UI Options"
- Add new Best Practice for building custom login UI
- Update QUICK_REFERENCE.md with warning comment
- Update SKILL.md Protected Routes example

https://claude.ai/code/session_01S8pH8AXWza6WkTZ233N8Z8