### PR TITLE
refactor: simplify skill descriptions with imperative language

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base44-cli
-description: "Use for Base44 CLI operations and project initialization. Triggers: user wants to create/initialize a new Base44 project; user mentions CLI commands (npx base44, yarn base44, create, login, logout, whoami, deploy, entities push, site deploy, functions deploy); directory is empty or missing base44/config.jsonc; user says 'create a Base44 app/project', 'setup Base44', 'deploy to Base44', 'push entities'. This skill is the PREREQUISITE for base44-sdk - always use this first for new projects before building features."
+description: "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions, ai agents), initialization and actions (resource creation, deployment). This skill is the place for learning about how to configure resources. When you plan or implement a feature, you must learn this skill"
 ---
 
 # Base44 CLI

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base44-sdk
-description: "**ALWAYS ACTIVATE** if ANY of these conditions are true: (1) User's prompt contains the word 'base44' or 'Base44' in ANY context; (2) Current directory contains a 'base44/' subfolder; (3) Code contains imports from '@base44/sdk'; (4) User mentions Base44 SDK modules: entities, auth, agents, functions, integrations, analytics. **ACTIVATION IS MANDATORY** - do not hesitate, do not search the web, do not read documentation files first. ACTIVATE IMMEDIATELY and let the skill instructions handle the context. This skill handles: application development, SDK usage, feature implementation, and writing code with Base44 APIs. The skill itself will determine the appropriate action based on whether this is a new project or existing project scenario."
+description: "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote resources (entities, backend functions, ai agents) and to write backend functions. This skill is the place for learning about available modules and types. When you plan or implement a feature, you must learn this skill"
 ---
 
 # Base44 Coder


### PR DESCRIPTION
## Summary

Simplified base44-cli and base44-sdk descriptions using shorter, more imperative language that proved more effective at triggering skill activation.

## Why This Works Better

Previous attempts with detailed trigger lists and "MANDATORY" prohibitions failed because:
- Claude stopped reading after mental categorization ("CLI tooling")
- Prohibitions at the end were ignored
- Long descriptions became "background noise"

The new approach:
- **"EVERYTHING"** - Broad scope without ambiguity
- **"must learn this skill"** - Imperative, implies reading content (not just activating)
- **"When you plan or implement"** - Explicitly covers planning phase
- **Short enough to read completely**

## Test Results

Claude now correctly invokes the skills during planning when working with Base44 agents/entities/functions.

Made with [Cursor](https://cursor.com)