### PR TITLE
Add connectors management to base44-cli skill

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -301,9 +301,10 @@ Connectors are OAuth integrations that let your app connect to external services
 | Action / Command            | Description                                     | Reference                                             |
 | --------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | Create Connectors           | Define connectors in `base44/connectors` folder | [connectors-create.md](references/connectors-create.md) |
+| `base44 connectors pull`    | Pull remote connectors to local files           | [connectors-pull.md](references/connectors-pull.md)   |
 | `base44 connectors push`    | Push local connectors to Base44                 | [connectors-push.md](references/connectors-push.md)   |
 
-**Note:** Pushing connectors syncs scopes and removes any connectors not defined locally. New connectors require OAuth authorization in your browser.
+**Note:** Connector commands perform full synchronization - pushing replaces all remote connectors with local ones (and triggers OAuth for new ones), and pulling replaces all local connectors with remote ones.
 
 #### Connector Schema (Quick Reference)
 
@@ -403,6 +404,7 @@ Or deploy individual resources:
 - `npx base44 entities push` - Push entities only
 - `npx base44 functions deploy` - Deploy functions only
 - `npx base44 agents push` - Push agents only
+- `npx base44 connectors pull` - Pull connectors from Base44
 - `npx base44 connectors push` - Push connectors only
 - `npx base44 site deploy -y` - Deploy site only
 
@@ -453,6 +455,9 @@ npx base44 functions deploy
 
 # Push only agents
 npx base44 agents push
+
+# Pull connectors from Base44
+npx base44 connectors pull
 
 # Push only connectors
 npx base44 connectors push

--- a/skills/base44-cli/references/connectors-create.md
+++ b/skills/base44-cli/references/connectors-create.md
@@ -126,3 +126,11 @@ npx base44 connectors push
 ```
 
 This will prompt you to authorize each new connector in your browser. See [connectors-push.md](connectors-push.md) for details.
+
+To pull existing connectors from Base44 to local files:
+
+```bash
+npx base44 connectors pull
+```
+
+See [connectors-pull.md](connectors-pull.md) for details.

--- a/skills/base44-cli/references/connectors-pull.md
+++ b/skills/base44-cli/references/connectors-pull.md
@@ -1,0 +1,78 @@
+# base44 connectors pull
+
+Pull connector configurations from Base44 to local files. Replaces all local connector configs with the remote versions.
+
+## Syntax
+
+```bash
+npx base44 connectors pull
+```
+
+## Authentication
+
+**Required**: Yes. If not authenticated, you'll be prompted to login first.
+
+## What It Does
+
+1. Fetches all connectors from Base44
+2. Writes connector files to the `base44/connectors/` directory
+3. Deletes local connector files that don't exist remotely
+4. Reports written and deleted connectors
+
+## Prerequisites
+
+- Must be run from a Base44 project directory
+- Project must be linked to a Base44 app
+
+## Output
+
+```bash
+$ npx base44 connectors pull
+
+Fetching connectors from Base44...
+✓ Connectors fetched successfully
+
+Syncing connector files...
+✓ Connector files synced successfully
+
+Written: googlecalendar, slack
+Deleted: notion
+
+Pulled 2 connectors to base44/connectors
+```
+
+## Connector Synchronization
+
+The pull operation synchronizes remote connectors to your local files:
+
+- **Written**: Connector files created or updated from remote
+- **Deleted**: Local connector files removed (didn't exist remotely)
+- **Up to date**: If no changes needed, reports "All connectors are already up to date"
+
+**Warning**: This operation replaces all local connector configurations with remote versions. Any local changes not pushed to Base44 will be overwritten.
+
+## Error Handling
+
+If no connectors exist on Base44:
+```bash
+$ npx base44 connectors pull
+All connectors are already up to date
+```
+
+## Use Cases
+
+- Sync connector configurations to a new development machine
+- Get the latest connector configurations from your team
+- Restore local connector files after accidental deletion
+- Start working on an existing project with connectors
+
+## Notes
+
+- Connector files are stored as `.jsonc` in the `base44/connectors/` directory
+- The directory location is configurable via `connectorsDir` in `config.jsonc`
+- Use `base44 connectors push` to upload local changes to Base44
+
+## Related Commands
+
+- [connectors-create.md](connectors-create.md) - How to create connector configuration files
+- [connectors-push.md](connectors-push.md) - Push local connectors to Base44

--- a/skills/base44-cli/references/connectors-push.md
+++ b/skills/base44-cli/references/connectors-push.md
@@ -118,3 +118,4 @@ Run the command again when you're ready to authorize.
 ## Related Commands
 
 - [connectors-create.md](connectors-create.md) - How to create connector configuration files
+- [connectors-pull.md](connectors-pull.md) - Pull connectors from Base44 to local files


### PR DESCRIPTION
## Summary

- Add documentation for the new "connectors" feature in the Base44 CLI
- Connectors are OAuth integrations that let apps connect to external services (Google Calendar, Slack, Notion, etc.)

## Changes

**SKILL.md:**
- Added `connectors/` folder to project structure
- Added `connectorsDir` config property
- Added Connector Management section with command table and schema reference
- Updated deploy commands and troubleshooting

**New reference files:**
- `connectors-create.md` - How to create connector configuration files, supported types, and examples
- `connectors-push.md` - How to push connectors and handle OAuth authorization flow

## Supported Connectors

Google Calendar, Google Drive, Google Sheets, Google Docs, Google Slides, Gmail, Slack, Notion, Salesforce, HubSpot, LinkedIn, TikTok


Made with [Cursor](https://cursor.com)