### PR TITLE
test: add status reference doc to base44-cli skill

### DIFF
--- a/skills/base44-cli/references/status.md
+++ b/skills/base44-cli/references/status.md
@@ -1,0 +1,13 @@
+# base44 status
+
+Check the status of the current Base44 project.
+
+## Usage
+
+```bash
+npx base44 status
+```
+
+## Description
+
+Displays the current project's configuration status, including linked app, authenticated user, and deployed state.


### PR DESCRIPTION
## Summary

- Adds a reference document (`status.md`) to the existing `base44-cli` skill
- The `readme-check` workflow should trigger (path matches `skills/**`) but find **no discrepancies** since `base44-cli` is already in the README table

## Test plan

- [ ] Verify the `readme-check` workflow triggers on this PR
- [ ] Verify it finds no discrepancies and comments "README is up to date"
- [ ] Verify no auto-commit is made to the README

Made with [Cursor](https://cursor.com)