### PR TITLE
fix: readme-check tool permissions and prompt clarity

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -50,7 +50,15 @@ jobs:
 
             RULES:
             1. If everything matches: If the PR number line above has a number, run: gh pr comment <that number> --body "README check ran. README is up to date." If it is empty (manual run), print "README check ran. README is up to date." to the terminal and exit.
-            2. If you find discrepancies: Update README.md with the correct content (use the Write tool). If the PR number line above has a number (i.e. this is a PR-triggered run), commit and push the fix: git config user.name "github-actions[bot]"; git config user.email "github-actions[bot]@users.noreply.github.com"; git add README.md; git commit -m "docs: update README to match skills (skill table, install, or links)"; git push. Then post one short comment with gh pr comment <that number> --body "..." summarizing what was fixed (e.g. "README check ran. N issue(s) found and applied: [brief list]. README.md has been updated in this branch."; escape the body for the shell). If the PR number is empty (manual/workflow_dispatch run), do NOT run git push. Instead, print the summary of discrepancies to the terminal so the user can review them.
+            2. If you find discrepancies: Update README.md with the correct content (use the Write or Edit tool). If the PR number line above has a number (i.e. this is a PR-triggered run), commit and push the fix by running each git command as a SEPARATE Bash call (do NOT chain with && or ;):
+               - git config user.name "github-actions[bot]"
+               - git config user.email "github-actions[bot]@users.noreply.github.com"
+               - git add README.md
+               - git commit -m "docs: update README to match skills (skill table, install, or links)"
+               - git push
+               Then post one short comment with gh pr comment <that number> --body "..." summarizing what was fixed (e.g. "README check ran. N issue(s) found and applied: [brief list]. README.md has been updated in this branch."; escape the body for the shell).
+               IMPORTANT: Only post the comment AFTER confirming that git push succeeded. If any step failed, say so in the comment.
+               If the PR number is empty (manual/workflow_dispatch run), do NOT run git push. Instead, print the summary of discrepancies to the terminal so the user can review them.
             3. The PR comment or terminal output must only state that the check ran and the conclusion. Do not paste full diffs or long suggestion lists.
-          claude_args: '--allowed-tools Read Glob Grep Write "Bash(gh pr comment:*)" "Bash(git config *)" "Bash(git add *)" "Bash(git commit *)" "Bash(git push *)"'
+          claude_args: '--allowed-tools Read Glob Grep Write Edit "Bash(gh pr comment:*)" "Bash(git config *)" "Bash(git add *)" "Bash(git commit *)" "Bash(git push)" "Bash(git push *)"'
           allowed_bots: 'claude[bot]'


### PR DESCRIPTION
## Summary

- Fixes the `readme-check` workflow where Claude's tool calls were **silently denied** by the `claude_args` sandbox, causing it to post a misleading "README updated" comment while nothing actually changed (see PR #72)
- Root causes: `Edit` tool not allowed, chained git commands rejected by individual Bash patterns, bare `git push` not matching `Bash(git push *)`

## Changes

- **`claude_args`**: Added `Edit` to allowed tools; added `Bash(git push)` pattern for bare push
- **Prompt**: Instructs agent to run git commands as separate Bash calls (not chained with `&&`/`;`); only post PR comment after confirming push succeeded

## Test plan

- [ ] Merge this PR to `main`
- [ ] Re-trigger the workflow on PR #72 (which adds a new skill not in the README table)
- [ ] Verify the agent successfully edits README.md, commits, pushes, and comments accurately

Made with [Cursor](https://cursor.com)