### PR TITLE
Update all CLI references to use npx base44@latest

### DIFF
--- a/.claude/skills/sync-cli-skill/SKILL.md
+++ b/.claude/skills/sync-cli-skill/SKILL.md
@@ -235,8 +235,8 @@ Documented (references/create.md):
 
 Changes detected:
   - BREAKING: --name (-n) option converted to positional argument <name>
-    Old syntax: npx base44@latestcreate -n my-app
-    New syntax: npx base44@latestcreate my-app
+    Old syntax: npx base44@latest create -n my-app
+    New syntax: npx base44@latest create my-app
 ```
 
 #### Step 5c: Update Reference File
@@ -321,8 +321,8 @@ After all updates, present a summary to the user:
 
 ### Breaking Changes (highlight prominently)
 - `create`: `-n, --name` option converted to positional argument
-  - Old: `npx base44@latestcreate -n my-app`
-  - New: `npx base44@latestcreate my-app`
+  - Old: `npx base44@latest create -n my-app`
+  - New: `npx base44@latest create my-app`
 
 ### Option Changes
 - `deploy --env`: now required (was optional)

--- a/.claude/skills/sync-cli-skill/SKILL.md
+++ b/.claude/skills/sync-cli-skill/SKILL.md
@@ -235,8 +235,8 @@ Documented (references/create.md):
 
 Changes detected:
   - BREAKING: --name (-n) option converted to positional argument <name>
-    Old syntax: npx base44 create -n my-app
-    New syntax: npx base44 create my-app
+    Old syntax: npx base44@latestcreate -n my-app
+    New syntax: npx base44@latestcreate my-app
 ```
 
 #### Step 5c: Update Reference File
@@ -251,7 +251,7 @@ Update or create `references/{command-name}.md` with the following format:
 ## Syntax
 
 ```bash
-npx base44 {command} [options]
+npx base44@latest{command} [options]
 ```
 
 ## Options
@@ -321,8 +321,8 @@ After all updates, present a summary to the user:
 
 ### Breaking Changes (highlight prominently)
 - `create`: `-n, --name` option converted to positional argument
-  - Old: `npx base44 create -n my-app`
-  - New: `npx base44 create my-app`
+  - Old: `npx base44@latestcreate -n my-app`
+  - New: `npx base44@latestcreate my-app`
 
 ### Option Changes
 - `deploy --env`: now required (was optional)

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -25,12 +25,14 @@ This skill activates on ANY mention of "base44" or when a `base44/` folder exist
 
 NEVER call `base44` directly. The CLI is installed locally as a dev dependency and must be accessed via a package manager:
 
-- `npx base44 <command>` (npm - recommended)
+- `npx base44@latest <command>` (npm - recommended)
 - `yarn base44 <command>` (yarn)
 - `pnpm base44 <command>` (pnpm)
 
+**IMPORTANT: Always use `@latest` with npx to ensure you're running the most recent version of the base44 CLI.**
+
 WRONG: `base44 login`
-RIGHT: `npx base44 login`
+RIGHT: `npx base44@latest login`
 
 ## MANDATORY: Authentication Check at Session Start
 
@@ -38,7 +40,7 @@ RIGHT: `npx base44 login`
 
 1. **Check authentication status** by running:
    ```bash
-   npx base44 whoami
+   npx base44@latest whoami
    ```
 
 2. **If the user is logged in** (command succeeds and shows an email):
@@ -49,7 +51,7 @@ RIGHT: `npx base44 login`
    - **DO NOT proceed** with any CLI operations
    - **Ask the user to login manually** by running:
      ```bash
-     npx base44 login
+     npx base44@latest login
    ```
    - Wait for the user to confirm they have logged in before continuing
 
@@ -67,7 +69,7 @@ The Base44 CLI provides command-line tools for authentication, creating projects
 - Directory is missing `base44/config.jsonc`
 - User mentions: "create a new project", "initialize project", "setup a project", "start a new Base44 app"
 - Deploying, pushing entities, or authenticating via CLI
-- Working with CLI commands (`npx base44 ...`)
+- Working with CLI commands (`npx base44@latest...`)
 
 **Use base44-sdk when:**
 - Building features in an **EXISTING** Base44 project
@@ -126,7 +128,7 @@ my-app/
 - `base44/entities/*.jsonc` - Data model schemas (see Entity Schema section)
 - `base44/functions/*/function.jsonc` - Function config and optional `automations` (CRON, simple triggers, entity hooks)
 - `base44/agents/*.jsonc` - Agent configurations (optional)
-- `base44/.types/types.d.ts` - Auto-generated TypeScript types for entities, functions, and agents (created by `npx base44 types generate`)
+- `base44/.types/types.d.ts` - Auto-generated TypeScript types for entities, functions, and agents (created by `npx base44@latesttypes generate`)
 - `base44/connectors/*.jsonc` - OAuth connector configurations (optional)
 - `src/api/base44Client.js` - Pre-configured SDK client for frontend use
 
@@ -176,7 +178,7 @@ npm install --save-dev base44
 Then run commands using `npx`:
 
 ```bash
-npx base44 <command>
+npx base44@latest<command>
 ```
 
 **Note:** All commands in this documentation use `npx base44`. You can also use `yarn base44`, or `pnpm base44` if preferred.
@@ -386,27 +388,27 @@ For full schemas and examples, see [automations.md](references/automations.md).
 
 2. Authenticate with Base44:
    ```bash
-   npx base44 login
+   npx base44@latestlogin
    ```
 
 3. Create a new project (ALWAYS provide name and `--path` flag):
    ```bash
-   npx base44 create my-app -p .
+   npx base44@latestcreate my-app -p .
    ```
 
 4. Build and deploy everything:
    ```bash
    npm run build
-   npx base44 deploy -y
+   npx base44@latestdeploy -y
    ```
 
 Or deploy individual resources:
-- `npx base44 entities push` - Push entities only
-- `npx base44 functions deploy` - Deploy functions only
-- `npx base44 agents push` - Push agents only
-- `npx base44 connectors pull` - Pull connectors from Base44
-- `npx base44 connectors push` - Push connectors only
-- `npx base44 site deploy -y` - Deploy site only
+- `npx base44@latestentities push` - Push entities only
+- `npx base44@latestfunctions deploy` - Deploy functions only
+- `npx base44@latestagents push` - Push agents only
+- `npx base44@latestconnectors pull` - Pull connectors from Base44
+- `npx base44@latestconnectors push` - Push connectors only
+- `npx base44@latestsite deploy -y` - Deploy site only
 
 ## Common Workflows
 
@@ -422,25 +424,25 @@ Failure to follow the create.md instructions will result in broken project scaff
 ### Linking an Existing Project
 ```bash
 # If you have base44/config.jsonc but no .app.jsonc
-npx base44 link --create --name my-app
+npx base44@latestlink --create --name my-app
 ```
 
 ### Deploying All Changes
 ```bash
 # Generate types (optional, for TypeScript projects)
-npx base44 types generate
+npx base44@latesttypes generate
 
 # Build your project first
 npm run build
 
 # Deploy everything (entities, functions, and site)
-npx base44 deploy -y
+npx base44@latestdeploy -y
 ```
 
 ### Generating TypeScript Types
 ```bash
 # Generate types from entities, functions, and agents
-npx base44 types generate
+npx base44@latesttypes generate
 ```
 
 This creates `base44/.types/types.d.ts` with typed registries for the `@base44/sdk` module. Run this after changing entities, functions, or agents to keep your types in sync. No authentication required.
@@ -448,28 +450,28 @@ This creates `base44/.types/types.d.ts` with typed registries for the `@base44/s
 ### Deploying Individual Resources
 ```bash
 # Push only entities
-npx base44 entities push
+npx base44@latestentities push
 
 # Deploy only functions
-npx base44 functions deploy
+npx base44@latestfunctions deploy
 
 # Push only agents
-npx base44 agents push
+npx base44@latestagents push
 
 # Pull connectors from Base44
-npx base44 connectors pull
+npx base44@latestconnectors pull
 
 # Push only connectors
-npx base44 connectors push
+npx base44@latestconnectors push
 
 # Deploy only site
-npx base44 site deploy -y
+npx base44@latestsite deploy -y
 ```
 
 ### Opening the Dashboard
 ```bash
 # Open app dashboard in browser
-npx base44 dashboard
+npx base44@latestdashboard
 ```
 
 ## Authentication
@@ -480,7 +482,7 @@ Most commands require authentication. If you're not logged in, the CLI will auto
 
 | Error                       | Solution                                                                            |
 | --------------------------- | ----------------------------------------------------------------------------------- |
-| Not authenticated           | Run `npx base44 login` first                                                        |
+| Not authenticated           | Run `npx base44@latestlogin` first                                                        |
 | No entities found           | Ensure entities exist in `base44/entities/` directory                               |
 | Entity not recognized       | Ensure file uses kebab-case naming (e.g., `team-member.jsonc` not `TeamMember.jsonc`) |
 | No functions found          | Ensure functions exist in `base44/functions/` with valid `function.jsonc` configs   |
@@ -489,7 +491,7 @@ Most commands require authentication. If you're not logged in, the CLI will auto
 | No connectors found         | Ensure connectors exist in `base44/connectors/` directory with valid `.jsonc` configs |
 | Invalid connector type      | Connector `type` must be one of the supported services (googlecalendar, slack, etc.) |
 | Duplicate connector type    | Each connector type can only be defined once per project                            |
-| Connector authorization timeout | Re-run `npx base44 connectors push` and complete the OAuth flow in your browser  |
+| Connector authorization timeout | Re-run `npx base44@latestconnectors push` and complete the OAuth flow in your browser  |
 | No site configuration found | Check that `site.outputDirectory` is configured in project config                   |
 | Site deployment fails       | Ensure you ran `npm run build` first and the build succeeded                        |
 | Update available message    | If prompted to update, run `npm install -g base44@latest` (or use npx for local installs) |

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -128,7 +128,7 @@ my-app/
 - `base44/entities/*.jsonc` - Data model schemas (see Entity Schema section)
 - `base44/functions/*/function.jsonc` - Function config and optional `automations` (CRON, simple triggers, entity hooks)
 - `base44/agents/*.jsonc` - Agent configurations (optional)
-- `base44/.types/types.d.ts` - Auto-generated TypeScript types for entities, functions, and agents (created by `npx base44@latesttypes generate`)
+- `base44/.types/types.d.ts` - Auto-generated TypeScript types for entities, functions, and agents (created by `npx base44@latest types generate`)
 - `base44/connectors/*.jsonc` - OAuth connector configurations (optional)
 - `src/api/base44Client.js` - Pre-configured SDK client for frontend use
 
@@ -178,7 +178,7 @@ npm install --save-dev base44
 Then run commands using `npx`:
 
 ```bash
-npx base44@latest<command>
+npx base44@latest <command>
 ```
 
 **Note:** All commands in this documentation use `npx base44`. You can also use `yarn base44`, or `pnpm base44` if preferred.
@@ -388,27 +388,27 @@ For full schemas and examples, see [automations.md](references/automations.md).
 
 2. Authenticate with Base44:
    ```bash
-   npx base44@latestlogin
+   npx base44@latest login
    ```
 
 3. Create a new project (ALWAYS provide name and `--path` flag):
    ```bash
-   npx base44@latestcreate my-app -p .
+   npx base44@latest create my-app -p .
    ```
 
 4. Build and deploy everything:
    ```bash
    npm run build
-   npx base44@latestdeploy -y
+   npx base44@latest deploy -y
    ```
 
 Or deploy individual resources:
-- `npx base44@latestentities push` - Push entities only
-- `npx base44@latestfunctions deploy` - Deploy functions only
-- `npx base44@latestagents push` - Push agents only
-- `npx base44@latestconnectors pull` - Pull connectors from Base44
-- `npx base44@latestconnectors push` - Push connectors only
-- `npx base44@latestsite deploy -y` - Deploy site only
+- `npx base44@latest entities push` - Push entities only
+- `npx base44@latest functions deploy` - Deploy functions only
+- `npx base44@latest agents push` - Push agents only
+- `npx base44@latest connectors pull` - Pull connectors from Base44
+- `npx base44@latest connectors push` - Push connectors only
+- `npx base44@latest site deploy -y` - Deploy site only
 
 ## Common Workflows
 
@@ -424,25 +424,25 @@ Failure to follow the create.md instructions will result in broken project scaff
 ### Linking an Existing Project
 ```bash
 # If you have base44/config.jsonc but no .app.jsonc
-npx base44@latestlink --create --name my-app
+npx base44@latest link --create --name my-app
 ```
 
 ### Deploying All Changes
 ```bash
 # Generate types (optional, for TypeScript projects)
-npx base44@latesttypes generate
+npx base44@latest types generate
 
 # Build your project first
 npm run build
 
 # Deploy everything (entities, functions, and site)
-npx base44@latestdeploy -y
+npx base44@latest deploy -y
 ```
 
 ### Generating TypeScript Types
 ```bash
 # Generate types from entities, functions, and agents
-npx base44@latesttypes generate
+npx base44@latest types generate
 ```
 
 This creates `base44/.types/types.d.ts` with typed registries for the `@base44/sdk` module. Run this after changing entities, functions, or agents to keep your types in sync. No authentication required.
@@ -450,28 +450,28 @@ This creates `base44/.types/types.d.ts` with typed registries for the `@base44/s
 ### Deploying Individual Resources
 ```bash
 # Push only entities
-npx base44@latestentities push
+npx base44@latest entities push
 
 # Deploy only functions
-npx base44@latestfunctions deploy
+npx base44@latest functions deploy
 
 # Push only agents
-npx base44@latestagents push
+npx base44@latest agents push
 
 # Pull connectors from Base44
-npx base44@latestconnectors pull
+npx base44@latest connectors pull
 
 # Push only connectors
-npx base44@latestconnectors push
+npx base44@latest connectors push
 
 # Deploy only site
-npx base44@latestsite deploy -y
+npx base44@latest site deploy -y
 ```
 
 ### Opening the Dashboard
 ```bash
 # Open app dashboard in browser
-npx base44@latestdashboard
+npx base44@latest dashboard
 ```
 
 ## Authentication
@@ -482,7 +482,7 @@ Most commands require authentication. If you're not logged in, the CLI will auto
 
 | Error                       | Solution                                                                            |
 | --------------------------- | ----------------------------------------------------------------------------------- |
-| Not authenticated           | Run `npx base44@latestlogin` first                                                        |
+| Not authenticated           | Run `npx base44@latest login` first                                                        |
 | No entities found           | Ensure entities exist in `base44/entities/` directory                               |
 | Entity not recognized       | Ensure file uses kebab-case naming (e.g., `team-member.jsonc` not `TeamMember.jsonc`) |
 | No functions found          | Ensure functions exist in `base44/functions/` with valid `function.jsonc` configs   |
@@ -491,7 +491,7 @@ Most commands require authentication. If you're not logged in, the CLI will auto
 | No connectors found         | Ensure connectors exist in `base44/connectors/` directory with valid `.jsonc` configs |
 | Invalid connector type      | Connector `type` must be one of the supported services (googlecalendar, slack, etc.) |
 | Duplicate connector type    | Each connector type can only be defined once per project                            |
-| Connector authorization timeout | Re-run `npx base44@latestconnectors push` and complete the OAuth flow in your browser  |
+| Connector authorization timeout | Re-run `npx base44@latest connectors push` and complete the OAuth flow in your browser  |
 | No site configuration found | Check that `site.outputDirectory` is configured in project config                   |
 | Site deployment fails       | Ensure you ran `npm run build` first and the build succeeded                        |
 | Update available message    | If prompted to update, run `npm install -g base44@latest` (or use npx for local installs) |

--- a/skills/base44-cli/references/agents-pull.md
+++ b/skills/base44-cli/references/agents-pull.md
@@ -5,7 +5,7 @@ Pull AI agent configurations from Base44 to local files. Agents are conversation
 ## Syntax
 
 ```bash
-npx base44@latestagents pull
+npx base44@latest agents pull
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ npx base44@latestagents pull
 ## Output
 
 ```bash
-$ npx base44@latestagents pull
+$ npx base44@latest agents pull
 
 Fetching agents from Base44...
 ✓ Agents fetched successfully
@@ -54,7 +54,7 @@ The pull operation synchronizes remote agents to your local files:
 
 If no agents exist on Base44:
 ```bash
-$ npx base44@latestagents pull
+$ npx base44@latest agents pull
 No agents found on Base44
 ```
 

--- a/skills/base44-cli/references/agents-pull.md
+++ b/skills/base44-cli/references/agents-pull.md
@@ -5,7 +5,7 @@ Pull AI agent configurations from Base44 to local files. Agents are conversation
 ## Syntax
 
 ```bash
-npx base44 agents pull
+npx base44@latestagents pull
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ npx base44 agents pull
 ## Output
 
 ```bash
-$ npx base44 agents pull
+$ npx base44@latestagents pull
 
 Fetching agents from Base44...
 ✓ Agents fetched successfully
@@ -54,7 +54,7 @@ The pull operation synchronizes remote agents to your local files:
 
 If no agents exist on Base44:
 ```bash
-$ npx base44 agents pull
+$ npx base44@latestagents pull
 No agents found on Base44
 ```
 

--- a/skills/base44-cli/references/agents-push.md
+++ b/skills/base44-cli/references/agents-push.md
@@ -5,7 +5,7 @@ Push local AI agent configurations to Base44. Agents are conversational AI assis
 ## Syntax
 
 ```bash
-npx base44@latestagents push
+npx base44@latest agents push
 ```
 
 ## Authentication
@@ -28,7 +28,7 @@ npx base44@latestagents push
 ## Output
 
 ```bash
-$ npx base44@latestagents push
+$ npx base44@latest agents push
 
 Found 2 agents to push
 Pushing agents to Base44...
@@ -54,13 +54,13 @@ The push operation synchronizes your local agents with Base44:
 
 If no agents are found in your project:
 ```bash
-$ npx base44@latestagents push
+$ npx base44@latest agents push
 No local agents found - this will delete all remote agents
 ```
 
 If an agent has an invalid name:
 ```bash
-$ npx base44@latestagents push
+$ npx base44@latest agents push
 Error: Agent name must be lowercase alphanumeric with underscores
 ```
 

--- a/skills/base44-cli/references/agents-push.md
+++ b/skills/base44-cli/references/agents-push.md
@@ -5,7 +5,7 @@ Push local AI agent configurations to Base44. Agents are conversational AI assis
 ## Syntax
 
 ```bash
-npx base44 agents push
+npx base44@latestagents push
 ```
 
 ## Authentication
@@ -28,7 +28,7 @@ npx base44 agents push
 ## Output
 
 ```bash
-$ npx base44 agents push
+$ npx base44@latestagents push
 
 Found 2 agents to push
 Pushing agents to Base44...
@@ -54,13 +54,13 @@ The push operation synchronizes your local agents with Base44:
 
 If no agents are found in your project:
 ```bash
-$ npx base44 agents push
+$ npx base44@latestagents push
 No local agents found - this will delete all remote agents
 ```
 
 If an agent has an invalid name:
 ```bash
-$ npx base44 agents push
+$ npx base44@latestagents push
 Error: Agent name must be lowercase alphanumeric with underscores
 ```
 

--- a/skills/base44-cli/references/auth-login.md
+++ b/skills/base44-cli/references/auth-login.md
@@ -5,7 +5,7 @@ Authenticate with Base44 using device code flow.
 ## Syntax
 
 ```bash
-npx base44 login
+npx base44@latestlogin
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ The login command uses OAuth 2.0 device code flow for authentication:
 ## Interactive Flow
 
 ```bash
-$ npx base44 login
+$ npx base44@latestlogin
 
 Please visit: https://auth.base44.com/device
 Enter code: ABCD-EFGH
@@ -44,8 +44,8 @@ Logged in as: user@example.com
 - Tokens include expiration timestamps
 - The session persists across CLI sessions
 - Other commands will automatically use your stored credentials
-- Use `npx base44 logout` to clear your session
-- Use `npx base44 whoami` to check your current authentication status
+- Use `npx base44@latestlogout` to clear your session
+- Use `npx base44@latestwhoami` to check your current authentication status
 
 ## Notes
 

--- a/skills/base44-cli/references/auth-login.md
+++ b/skills/base44-cli/references/auth-login.md
@@ -5,7 +5,7 @@ Authenticate with Base44 using device code flow.
 ## Syntax
 
 ```bash
-npx base44@latestlogin
+npx base44@latest login
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ The login command uses OAuth 2.0 device code flow for authentication:
 ## Interactive Flow
 
 ```bash
-$ npx base44@latestlogin
+$ npx base44@latest login
 
 Please visit: https://auth.base44.com/device
 Enter code: ABCD-EFGH
@@ -44,8 +44,8 @@ Logged in as: user@example.com
 - Tokens include expiration timestamps
 - The session persists across CLI sessions
 - Other commands will automatically use your stored credentials
-- Use `npx base44@latestlogout` to clear your session
-- Use `npx base44@latestwhoami` to check your current authentication status
+- Use `npx base44@latest logout` to clear your session
+- Use `npx base44@latest whoami` to check your current authentication status
 
 ## Notes
 

--- a/skills/base44-cli/references/auth-logout.md
+++ b/skills/base44-cli/references/auth-logout.md
@@ -5,7 +5,7 @@ Logout from current device and clear stored authentication data.
 ## Syntax
 
 ```bash
-npx base44 logout
+npx base44@latestlogout
 ```
 
 ## Authentication
@@ -21,12 +21,12 @@ npx base44 logout
 ## Output
 
 ```bash
-$ npx base44 logout
+$ npx base44@latestlogout
 Logged out successfully
 ```
 
 ## Notes
 
 - You can logout even if you're not currently logged in (no error)
-- After logout, you'll need to run `npx base44 login` again to use authenticated commands
+- After logout, you'll need to run `npx base44@latestlogin` again to use authenticated commands
 - This only affects the current device; your Base44 account remains active

--- a/skills/base44-cli/references/auth-logout.md
+++ b/skills/base44-cli/references/auth-logout.md
@@ -5,7 +5,7 @@ Logout from current device and clear stored authentication data.
 ## Syntax
 
 ```bash
-npx base44@latestlogout
+npx base44@latest logout
 ```
 
 ## Authentication
@@ -21,12 +21,12 @@ npx base44@latestlogout
 ## Output
 
 ```bash
-$ npx base44@latestlogout
+$ npx base44@latest logout
 Logged out successfully
 ```
 
 ## Notes
 
 - You can logout even if you're not currently logged in (no error)
-- After logout, you'll need to run `npx base44@latestlogin` again to use authenticated commands
+- After logout, you'll need to run `npx base44@latest login` again to use authenticated commands
 - This only affects the current device; your Base44 account remains active

--- a/skills/base44-cli/references/auth-whoami.md
+++ b/skills/base44-cli/references/auth-whoami.md
@@ -5,7 +5,7 @@ Display the currently authenticated user.
 ## Syntax
 
 ```bash
-npx base44 whoami
+npx base44@latestwhoami
 ```
 
 ## Authentication
@@ -20,7 +20,7 @@ npx base44 whoami
 ## Output
 
 ```bash
-$ npx base44 whoami
+$ npx base44@latestwhoami
 Logged in as: user@example.com
 ```
 

--- a/skills/base44-cli/references/auth-whoami.md
+++ b/skills/base44-cli/references/auth-whoami.md
@@ -5,7 +5,7 @@ Display the currently authenticated user.
 ## Syntax
 
 ```bash
-npx base44@latestwhoami
+npx base44@latest whoami
 ```
 
 ## Authentication
@@ -20,7 +20,7 @@ npx base44@latestwhoami
 ## Output
 
 ```bash
-$ npx base44@latestwhoami
+$ npx base44@latest whoami
 Logged in as: user@example.com
 ```
 

--- a/skills/base44-cli/references/automations.md
+++ b/skills/base44-cli/references/automations.md
@@ -1,6 +1,6 @@
 # Function Automations
 
-Automations are triggers attached to backend functions. They cause a function to run automatically on a schedule (CRON, simple interval, or one-time) or when entity data changes (create, update, delete). Automations are defined in the `automations` array inside each function's `function.jsonc` and are deployed together with the function via `npx base44@latestfunctions deploy`.
+Automations are triggers attached to backend functions. They cause a function to run automatically on a schedule (CRON, simple interval, or one-time) or when entity data changes (create, update, delete). Automations are defined in the `automations` array inside each function's `function.jsonc` and are deployed together with the function via `npx base44@latest functions deploy`.
 
 ## Overview
 
@@ -326,7 +326,7 @@ Deno.serve(async (req) => {
 Automations are deployed with their function. There is no separate automation deploy command.
 
 ```bash
-npx base44@latestfunctions deploy
+npx base44@latest functions deploy
 ```
 
 This deploys all functions in `base44/functions/` and their `automations` arrays. For more on deployment, see [functions-deploy.md](functions-deploy.md).
@@ -340,4 +340,4 @@ This deploys all functions in `base44/functions/` and their `automations` arrays
 | Assuming `base44.auth.me()` is the user who triggered the entity change | Use `data` / `old_data` (e.g. `created_by`, `updated_by`) if you need who did the action | In automations, `auth.me()` is the user who **created the automation**. The triggering user is not available. |
 | `schedule_type: "cron"` without `cron_expression` | Always set `cron_expression` for cron | Cron schedules require a valid cron expression |
 | Putting automations in a separate file | Put `automations` inside `function.jsonc` | Automations are part of the function config |
-| Expecting a separate `base44 automations deploy` | Use `npx base44@latestfunctions deploy` | Automations deploy with the function |
+| Expecting a separate `base44 automations deploy` | Use `npx base44@latest functions deploy` | Automations deploy with the function |

--- a/skills/base44-cli/references/automations.md
+++ b/skills/base44-cli/references/automations.md
@@ -1,6 +1,6 @@
 # Function Automations
 
-Automations are triggers attached to backend functions. They cause a function to run automatically on a schedule (CRON, simple interval, or one-time) or when entity data changes (create, update, delete). Automations are defined in the `automations` array inside each function's `function.jsonc` and are deployed together with the function via `npx base44 functions deploy`.
+Automations are triggers attached to backend functions. They cause a function to run automatically on a schedule (CRON, simple interval, or one-time) or when entity data changes (create, update, delete). Automations are defined in the `automations` array inside each function's `function.jsonc` and are deployed together with the function via `npx base44@latestfunctions deploy`.
 
 ## Overview
 
@@ -326,7 +326,7 @@ Deno.serve(async (req) => {
 Automations are deployed with their function. There is no separate automation deploy command.
 
 ```bash
-npx base44 functions deploy
+npx base44@latestfunctions deploy
 ```
 
 This deploys all functions in `base44/functions/` and their `automations` arrays. For more on deployment, see [functions-deploy.md](functions-deploy.md).
@@ -340,4 +340,4 @@ This deploys all functions in `base44/functions/` and their `automations` arrays
 | Assuming `base44.auth.me()` is the user who triggered the entity change | Use `data` / `old_data` (e.g. `created_by`, `updated_by`) if you need who did the action | In automations, `auth.me()` is the user who **created the automation**. The triggering user is not available. |
 | `schedule_type: "cron"` without `cron_expression` | Always set `cron_expression` for cron | Cron schedules require a valid cron expression |
 | Putting automations in a separate file | Put `automations` inside `function.jsonc` | Automations are part of the function config |
-| Expecting a separate `base44 automations deploy` | Use `npx base44 functions deploy` | Automations deploy with the function |
+| Expecting a separate `base44 automations deploy` | Use `npx base44@latestfunctions deploy` | Automations deploy with the function |

--- a/skills/base44-cli/references/connectors-create.md
+++ b/skills/base44-cli/references/connectors-create.md
@@ -122,7 +122,7 @@ Note: Notion uses a page-based access model where users select which pages to sh
 After creating connector files, push them to Base44:
 
 ```bash
-npx base44 connectors push
+npx base44@latestconnectors push
 ```
 
 This will prompt you to authorize each new connector in your browser. See [connectors-push.md](connectors-push.md) for details.
@@ -130,7 +130,7 @@ This will prompt you to authorize each new connector in your browser. See [conne
 To pull existing connectors from Base44 to local files:
 
 ```bash
-npx base44 connectors pull
+npx base44@latestconnectors pull
 ```
 
 See [connectors-pull.md](connectors-pull.md) for details.

--- a/skills/base44-cli/references/connectors-create.md
+++ b/skills/base44-cli/references/connectors-create.md
@@ -122,7 +122,7 @@ Note: Notion uses a page-based access model where users select which pages to sh
 After creating connector files, push them to Base44:
 
 ```bash
-npx base44@latestconnectors push
+npx base44@latest connectors push
 ```
 
 This will prompt you to authorize each new connector in your browser. See [connectors-push.md](connectors-push.md) for details.
@@ -130,7 +130,7 @@ This will prompt you to authorize each new connector in your browser. See [conne
 To pull existing connectors from Base44 to local files:
 
 ```bash
-npx base44@latestconnectors pull
+npx base44@latest connectors pull
 ```
 
 See [connectors-pull.md](connectors-pull.md) for details.

--- a/skills/base44-cli/references/connectors-pull.md
+++ b/skills/base44-cli/references/connectors-pull.md
@@ -5,7 +5,7 @@ Pull connector configurations from Base44 to local files. Replaces all local con
 ## Syntax
 
 ```bash
-npx base44 connectors pull
+npx base44@latestconnectors pull
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ npx base44 connectors pull
 ## Output
 
 ```bash
-$ npx base44 connectors pull
+$ npx base44@latestconnectors pull
 
 Fetching connectors from Base44...
 ✓ Connectors fetched successfully
@@ -55,7 +55,7 @@ The pull operation synchronizes remote connectors to your local files:
 
 If no connectors exist on Base44:
 ```bash
-$ npx base44 connectors pull
+$ npx base44@latestconnectors pull
 All connectors are already up to date
 ```
 

--- a/skills/base44-cli/references/connectors-pull.md
+++ b/skills/base44-cli/references/connectors-pull.md
@@ -5,7 +5,7 @@ Pull connector configurations from Base44 to local files. Replaces all local con
 ## Syntax
 
 ```bash
-npx base44@latestconnectors pull
+npx base44@latest connectors pull
 ```
 
 ## Authentication
@@ -27,7 +27,7 @@ npx base44@latestconnectors pull
 ## Output
 
 ```bash
-$ npx base44@latestconnectors pull
+$ npx base44@latest connectors pull
 
 Fetching connectors from Base44...
 ✓ Connectors fetched successfully
@@ -55,7 +55,7 @@ The pull operation synchronizes remote connectors to your local files:
 
 If no connectors exist on Base44:
 ```bash
-$ npx base44@latestconnectors pull
+$ npx base44@latest connectors pull
 All connectors are already up to date
 ```
 

--- a/skills/base44-cli/references/connectors-push.md
+++ b/skills/base44-cli/references/connectors-push.md
@@ -5,7 +5,7 @@ Push local connector configurations to Base44, synchronizing scopes and handling
 ## Usage
 
 ```bash
-npx base44@latestconnectors push
+npx base44@latest connectors push
 ```
 
 ## What It Does
@@ -83,7 +83,7 @@ In CI environments (when `CI` environment variable is set), the OAuth flow is sk
 Skipped OAuth in CI. Pending: slack, notion. Run 'base44 connectors push' locally to authorize.
 ```
 
-You must run `npx base44@latestconnectors push` locally to complete authorization for new connectors.
+You must run `npx base44@latest connectors push` locally to complete authorization for new connectors.
 
 ## Skipping Authorization
 
@@ -110,7 +110,7 @@ Run the command again when you're ready to authorize.
 
 | Problem | Solution |
 |---------|----------|
-| Authorization timed out | Re-run `npx base44@latestconnectors push` and complete OAuth faster |
+| Authorization timed out | Re-run `npx base44@latest connectors push` and complete OAuth faster |
 | Authorization failed | Check that you approved all requested permissions |
 | Wrong account connected | Remove the connector file, push to delete it, then add it back and authorize with the correct account |
 | Browser didn't open | Copy the URL shown in the terminal and open it manually |

--- a/skills/base44-cli/references/connectors-push.md
+++ b/skills/base44-cli/references/connectors-push.md
@@ -5,7 +5,7 @@ Push local connector configurations to Base44, synchronizing scopes and handling
 ## Usage
 
 ```bash
-npx base44 connectors push
+npx base44@latestconnectors push
 ```
 
 ## What It Does
@@ -83,7 +83,7 @@ In CI environments (when `CI` environment variable is set), the OAuth flow is sk
 Skipped OAuth in CI. Pending: slack, notion. Run 'base44 connectors push' locally to authorize.
 ```
 
-You must run `npx base44 connectors push` locally to complete authorization for new connectors.
+You must run `npx base44@latestconnectors push` locally to complete authorization for new connectors.
 
 ## Skipping Authorization
 
@@ -110,7 +110,7 @@ Run the command again when you're ready to authorize.
 
 | Problem | Solution |
 |---------|----------|
-| Authorization timed out | Re-run `npx base44 connectors push` and complete OAuth faster |
+| Authorization timed out | Re-run `npx base44@latestconnectors push` and complete OAuth faster |
 | Authorization failed | Check that you approved all requested permissions |
 | Wrong account connected | Remove the connector file, push to delete it, then add it back and authorize with the correct account |
 | Browser didn't open | Copy the URL shown in the terminal and open it manually |

--- a/skills/base44-cli/references/create.md
+++ b/skills/base44-cli/references/create.md
@@ -6,14 +6,14 @@ Creates a new Base44 project from a template. This command is framework-agnostic
 
 ALWAYS provide both the project name AND `--path` flag. Without both, the command opens an interactive TUI which agents cannot use properly.
 
-WRONG: `npx base44 create`
-WRONG: `npx base44 create my-app`
-RIGHT: `npx base44 create my-app -p ./my-app`
+WRONG: `npx base44@latestcreate`
+WRONG: `npx base44@latestcreate my-app`
+RIGHT: `npx base44@latestcreate my-app -p ./my-app`
 
 ## Syntax
 
 ```bash
-npx base44 create [name] --path <path> [options]
+npx base44@latestcreate [name] --path <path> [options]
 ```
 
 ## Arguments & Options
@@ -43,11 +43,11 @@ npx base44 create [name] --path <path> [options]
 
 - **For `backend-and-client` template (new projects):** Use a new subfolder path
   ```bash
-  npx base44 create my-app -p ./my-app -t backend-and-client
+  npx base44@latestcreate my-app -p ./my-app -t backend-and-client
   ```
 - **For `backend-only` template (existing projects):** Use `-p .` in the current directory
   ```bash
-  npx base44 create my-app -p .
+  npx base44@latestcreate my-app -p .
   ```
 
 ## Workflow: Using `backend-only` with External Frameworks
@@ -69,7 +69,7 @@ cd my-app
 npm install --save-dev base44
 
 # Step 4: Add Base44 configuration
-npx base44 create my-app -p .
+npx base44@latestcreate my-app -p .
 ```
 
 **WARNING:** Do NOT:
@@ -84,19 +84,19 @@ npx base44 create my-app -p .
 
 ```bash
 # RECOMMENDED: Create full-stack project (for new apps)
-npx base44 create my-app -p ./my-app -t backend-and-client
+npx base44@latestcreate my-app -p ./my-app -t backend-and-client
 
 # Create full-stack and deploy in one step
-npx base44 create my-app -p ./my-app -t backend-and-client --deploy
+npx base44@latestcreate my-app -p ./my-app -t backend-and-client --deploy
 
 # Add Base44 to EXISTING project (must be inside the project folder)
-npx base44 create my-app -p .
+npx base44@latestcreate my-app -p .
 
 # Add Base44 to existing project and deploy
-npx base44 create my-app -p . --deploy
+npx base44@latestcreate my-app -p . --deploy
 
 # Create without adding AI agent skills
-npx base44 create my-app -p . --no-skills
+npx base44@latestcreate my-app -p . --no-skills
 ```
 
 ## What It Does

--- a/skills/base44-cli/references/create.md
+++ b/skills/base44-cli/references/create.md
@@ -6,14 +6,14 @@ Creates a new Base44 project from a template. This command is framework-agnostic
 
 ALWAYS provide both the project name AND `--path` flag. Without both, the command opens an interactive TUI which agents cannot use properly.
 
-WRONG: `npx base44@latestcreate`
-WRONG: `npx base44@latestcreate my-app`
-RIGHT: `npx base44@latestcreate my-app -p ./my-app`
+WRONG: `npx base44@latest create`
+WRONG: `npx base44@latest create my-app`
+RIGHT: `npx base44@latest create my-app -p ./my-app`
 
 ## Syntax
 
 ```bash
-npx base44@latestcreate [name] --path <path> [options]
+npx base44@latest create [name] --path <path> [options]
 ```
 
 ## Arguments & Options
@@ -43,11 +43,11 @@ npx base44@latestcreate [name] --path <path> [options]
 
 - **For `backend-and-client` template (new projects):** Use a new subfolder path
   ```bash
-  npx base44@latestcreate my-app -p ./my-app -t backend-and-client
+  npx base44@latest create my-app -p ./my-app -t backend-and-client
   ```
 - **For `backend-only` template (existing projects):** Use `-p .` in the current directory
   ```bash
-  npx base44@latestcreate my-app -p .
+  npx base44@latest create my-app -p .
   ```
 
 ## Workflow: Using `backend-only` with External Frameworks
@@ -69,7 +69,7 @@ cd my-app
 npm install --save-dev base44
 
 # Step 4: Add Base44 configuration
-npx base44@latestcreate my-app -p .
+npx base44@latest create my-app -p .
 ```
 
 **WARNING:** Do NOT:
@@ -84,19 +84,19 @@ npx base44@latestcreate my-app -p .
 
 ```bash
 # RECOMMENDED: Create full-stack project (for new apps)
-npx base44@latestcreate my-app -p ./my-app -t backend-and-client
+npx base44@latest create my-app -p ./my-app -t backend-and-client
 
 # Create full-stack and deploy in one step
-npx base44@latestcreate my-app -p ./my-app -t backend-and-client --deploy
+npx base44@latest create my-app -p ./my-app -t backend-and-client --deploy
 
 # Add Base44 to EXISTING project (must be inside the project folder)
-npx base44@latestcreate my-app -p .
+npx base44@latest create my-app -p .
 
 # Add Base44 to existing project and deploy
-npx base44@latestcreate my-app -p . --deploy
+npx base44@latest create my-app -p . --deploy
 
 # Create without adding AI agent skills
-npx base44@latestcreate my-app -p . --no-skills
+npx base44@latest create my-app -p . --no-skills
 ```
 
 ## What It Does

--- a/skills/base44-cli/references/dashboard.md
+++ b/skills/base44-cli/references/dashboard.md
@@ -5,7 +5,7 @@ Opens the Base44 app dashboard in your default web browser.
 ## Syntax
 
 ```bash
-npx base44 dashboard open
+npx base44@latestdashboard open
 ```
 
 ## Authentication
@@ -22,13 +22,13 @@ npx base44 dashboard open
 
 ```bash
 # Open dashboard for current project
-npx base44 dashboard open
+npx base44@latestdashboard open
 ```
 
 ## Output
 
 ```bash
-$ npx base44 dashboard open
+$ npx base44@latestdashboard open
 
 Dashboard opened at https://base44.cloud/apps/your-app-id
 ```
@@ -36,7 +36,7 @@ Dashboard opened at https://base44.cloud/apps/your-app-id
 ## Requirements
 
 - Must be run from a linked Base44 project directory (contains `base44/.app.jsonc`)
-- Must be authenticated (run `npx base44 login` first)
+- Must be authenticated (run `npx base44@latestlogin` first)
 
 ## Notes
 

--- a/skills/base44-cli/references/dashboard.md
+++ b/skills/base44-cli/references/dashboard.md
@@ -5,7 +5,7 @@ Opens the Base44 app dashboard in your default web browser.
 ## Syntax
 
 ```bash
-npx base44@latestdashboard open
+npx base44@latest dashboard open
 ```
 
 ## Authentication
@@ -22,13 +22,13 @@ npx base44@latestdashboard open
 
 ```bash
 # Open dashboard for current project
-npx base44@latestdashboard open
+npx base44@latest dashboard open
 ```
 
 ## Output
 
 ```bash
-$ npx base44@latestdashboard open
+$ npx base44@latest dashboard open
 
 Dashboard opened at https://base44.cloud/apps/your-app-id
 ```
@@ -36,7 +36,7 @@ Dashboard opened at https://base44.cloud/apps/your-app-id
 ## Requirements
 
 - Must be run from a linked Base44 project directory (contains `base44/.app.jsonc`)
-- Must be authenticated (run `npx base44@latestlogin` first)
+- Must be authenticated (run `npx base44@latest login` first)
 
 ## Notes
 

--- a/skills/base44-cli/references/deploy.md
+++ b/skills/base44-cli/references/deploy.md
@@ -5,7 +5,7 @@ Deploys all project resources (entities, functions, and site) to Base44 in a sin
 ## Syntax
 
 ```bash
-npx base44@latestdeploy [options]
+npx base44@latest deploy [options]
 ```
 
 ## Options
@@ -27,10 +27,10 @@ The command automatically detects and deploys:
 
 ```bash
 # Interactive mode - shows what will be deployed and asks for confirmation
-npx base44@latestdeploy
+npx base44@latest deploy
 
 # Non-interactive - skip confirmation (for CI/CD or agent use)
-npx base44@latestdeploy -y
+npx base44@latest deploy -y
 ```
 
 ## Typical Workflow
@@ -42,7 +42,7 @@ npx base44@latestdeploy -y
 npm run build
 
 # 3. Deploy everything
-npx base44@latestdeploy -y
+npx base44@latest deploy -y
 ```
 
 ## What It Does
@@ -61,7 +61,7 @@ npx base44@latestdeploy -y
 ## Requirements
 
 - Must be run from a linked Base44 project directory
-- Must be authenticated (run `npx base44@latestlogin` first)
+- Must be authenticated (run `npx base44@latest login` first)
 - For site deployment, must run `npm run build` first
 
 ## Output

--- a/skills/base44-cli/references/deploy.md
+++ b/skills/base44-cli/references/deploy.md
@@ -5,7 +5,7 @@ Deploys all project resources (entities, functions, and site) to Base44 in a sin
 ## Syntax
 
 ```bash
-npx base44 deploy [options]
+npx base44@latestdeploy [options]
 ```
 
 ## Options
@@ -27,10 +27,10 @@ The command automatically detects and deploys:
 
 ```bash
 # Interactive mode - shows what will be deployed and asks for confirmation
-npx base44 deploy
+npx base44@latestdeploy
 
 # Non-interactive - skip confirmation (for CI/CD or agent use)
-npx base44 deploy -y
+npx base44@latestdeploy -y
 ```
 
 ## Typical Workflow
@@ -42,7 +42,7 @@ npx base44 deploy -y
 npm run build
 
 # 3. Deploy everything
-npx base44 deploy -y
+npx base44@latestdeploy -y
 ```
 
 ## What It Does
@@ -61,7 +61,7 @@ npx base44 deploy -y
 ## Requirements
 
 - Must be run from a linked Base44 project directory
-- Must be authenticated (run `npx base44 login` first)
+- Must be authenticated (run `npx base44@latestlogin` first)
 - For site deployment, must run `npm run build` first
 
 ## Output

--- a/skills/base44-cli/references/eject.md
+++ b/skills/base44-cli/references/eject.md
@@ -5,7 +5,7 @@ Download the code for an existing Base44 project to your local machine.
 ## Syntax
 
 ```bash
-npx base44@latesteject [options]
+npx base44@latest eject [options]
 ```
 
 ## Options
@@ -32,13 +32,13 @@ The `eject` command allows you to download the source code of a Base44 project t
 
 ```bash
 # Interactive mode - select project from list and specify path
-npx base44@latesteject
+npx base44@latest eject
 
 # Specify the output path
-npx base44@latesteject -p ./my-project
+npx base44@latest eject -p ./my-project
 
 # Non-interactive - specify project ID and skip confirmations
-npx base44@latesteject --project-id abc123 -p ./my-project -y
+npx base44@latest eject --project-id abc123 -p ./my-project -y
 ```
 
 ## Workflow
@@ -57,7 +57,7 @@ When you run `eject`:
 
 ## Requirements
 
-- Must be authenticated (run `npx base44@latestlogin` first)
+- Must be authenticated (run `npx base44@latest login` first)
 - The project must be ejectable (have managed source code)
 
 ## Use Cases

--- a/skills/base44-cli/references/eject.md
+++ b/skills/base44-cli/references/eject.md
@@ -5,7 +5,7 @@ Download the code for an existing Base44 project to your local machine.
 ## Syntax
 
 ```bash
-npx base44 eject [options]
+npx base44@latesteject [options]
 ```
 
 ## Options
@@ -32,13 +32,13 @@ The `eject` command allows you to download the source code of a Base44 project t
 
 ```bash
 # Interactive mode - select project from list and specify path
-npx base44 eject
+npx base44@latesteject
 
 # Specify the output path
-npx base44 eject -p ./my-project
+npx base44@latesteject -p ./my-project
 
 # Non-interactive - specify project ID and skip confirmations
-npx base44 eject --project-id abc123 -p ./my-project -y
+npx base44@latesteject --project-id abc123 -p ./my-project -y
 ```
 
 ## Workflow
@@ -57,7 +57,7 @@ When you run `eject`:
 
 ## Requirements
 
-- Must be authenticated (run `npx base44 login` first)
+- Must be authenticated (run `npx base44@latestlogin` first)
 - The project must be ejectable (have managed source code)
 
 ## Use Cases

--- a/skills/base44-cli/references/entities-create.md
+++ b/skills/base44-cli/references/entities-create.md
@@ -549,7 +549,7 @@ In this example, only users with the `hr` role can read or update the `salary` f
 The `entities push` command will push all entities that exist in the `base44/entities` folder.
 
 ```bash
-npx base44@latestentities push
+npx base44@latest entities push
 ```
 
 For more details on the push command, see [entities-push.md](entities-push.md).

--- a/skills/base44-cli/references/entities-create.md
+++ b/skills/base44-cli/references/entities-create.md
@@ -549,7 +549,7 @@ In this example, only users with the `hr` role can read or update the `salary` f
 The `entities push` command will push all entities that exist in the `base44/entities` folder.
 
 ```bash
-npx base44 entities push
+npx base44@latestentities push
 ```
 
 For more details on the push command, see [entities-push.md](entities-push.md).

--- a/skills/base44-cli/references/entities-push.md
+++ b/skills/base44-cli/references/entities-push.md
@@ -5,7 +5,7 @@ Push local entity definitions to Base44.
 ## Syntax
 
 ```bash
-npx base44@latestentities push
+npx base44@latest entities push
 ```
 
 ## Authentication
@@ -28,7 +28,7 @@ npx base44@latestentities push
 ## Output
 
 ```bash
-$ npx base44@latestentities push
+$ npx base44@latest entities push
 
 Found 3 entities to push
 Pushing entities to Base44...
@@ -52,7 +52,7 @@ The push operation synchronizes your local entity schema with Base44:
 
 If no entities are found in your project:
 ```bash
-$ npx base44@latestentities push
+$ npx base44@latest entities push
 No entities found in project
 ```
 

--- a/skills/base44-cli/references/entities-push.md
+++ b/skills/base44-cli/references/entities-push.md
@@ -5,7 +5,7 @@ Push local entity definitions to Base44.
 ## Syntax
 
 ```bash
-npx base44 entities push
+npx base44@latestentities push
 ```
 
 ## Authentication
@@ -28,7 +28,7 @@ npx base44 entities push
 ## Output
 
 ```bash
-$ npx base44 entities push
+$ npx base44@latestentities push
 
 Found 3 entities to push
 Pushing entities to Base44...
@@ -52,7 +52,7 @@ The push operation synchronizes your local entity schema with Base44:
 
 If no entities are found in your project:
 ```bash
-$ npx base44 entities push
+$ npx base44@latestentities push
 No entities found in project
 ```
 

--- a/skills/base44-cli/references/functions-create.md
+++ b/skills/base44-cli/references/functions-create.md
@@ -57,7 +57,7 @@ Each function requires a `function.jsonc` configuration file:
 
 ## Automations
 
-Functions can define automations (triggers) so they run on a schedule or when entity data changes. Add an optional `automations` array to `function.jsonc`. Supported types: **scheduled** (one-time, CRON, or simple interval) and **entity hooks** (on entity create/update/delete). Automations are deployed with the function via `npx base44 functions deploy`. For full schemas and examples, see [automations.md](automations.md).
+Functions can define automations (triggers) so they run on a schedule or when entity data changes. Add an optional `automations` array to `function.jsonc`. Supported types: **scheduled** (one-time, CRON, or simple interval) and **entity hooks** (on entity create/update/delete). Automations are deployed with the function via `npx base44@latestfunctions deploy`. For full schemas and examples, see [automations.md](automations.md).
 
 ## Entry Point File
 
@@ -222,7 +222,7 @@ Deno.serve(async (req) => {
 After creating your function, deploy it to Base44:
 
 ```bash
-npx base44 functions deploy
+npx base44@latestfunctions deploy
 ```
 
 For more details on deploying, see [functions-deploy.md](functions-deploy.md).

--- a/skills/base44-cli/references/functions-create.md
+++ b/skills/base44-cli/references/functions-create.md
@@ -57,7 +57,7 @@ Each function requires a `function.jsonc` configuration file:
 
 ## Automations
 
-Functions can define automations (triggers) so they run on a schedule or when entity data changes. Add an optional `automations` array to `function.jsonc`. Supported types: **scheduled** (one-time, CRON, or simple interval) and **entity hooks** (on entity create/update/delete). Automations are deployed with the function via `npx base44@latestfunctions deploy`. For full schemas and examples, see [automations.md](automations.md).
+Functions can define automations (triggers) so they run on a schedule or when entity data changes. Add an optional `automations` array to `function.jsonc`. Supported types: **scheduled** (one-time, CRON, or simple interval) and **entity hooks** (on entity create/update/delete). Automations are deployed with the function via `npx base44@latest functions deploy`. For full schemas and examples, see [automations.md](automations.md).
 
 ## Entry Point File
 
@@ -222,7 +222,7 @@ Deno.serve(async (req) => {
 After creating your function, deploy it to Base44:
 
 ```bash
-npx base44@latestfunctions deploy
+npx base44@latest functions deploy
 ```
 
 For more details on deploying, see [functions-deploy.md](functions-deploy.md).

--- a/skills/base44-cli/references/functions-deploy.md
+++ b/skills/base44-cli/references/functions-deploy.md
@@ -5,7 +5,7 @@ Deploy local function definitions to Base44.
 ## Syntax
 
 ```bash
-npx base44 functions deploy
+npx base44@latestfunctions deploy
 ```
 
 ## Authentication
@@ -29,7 +29,7 @@ npx base44 functions deploy
 ## Output
 
 ```bash
-$ npx base44 functions deploy
+$ npx base44@latestfunctions deploy
 
 Found 2 functions to deploy
 Deploying functions to Base44...
@@ -51,13 +51,13 @@ The deploy operation synchronizes your local functions with Base44:
 
 If no functions are found in your project:
 ```bash
-$ npx base44 functions deploy
+$ npx base44@latestfunctions deploy
 No functions found. Create functions in the 'functions' directory.
 ```
 
 If a function has configuration errors:
 ```bash
-$ npx base44 functions deploy
+$ npx base44@latestfunctions deploy
 Function deployment errors:
 'my-function' function: Entry point cannot be empty
 ```

--- a/skills/base44-cli/references/functions-deploy.md
+++ b/skills/base44-cli/references/functions-deploy.md
@@ -5,7 +5,7 @@ Deploy local function definitions to Base44.
 ## Syntax
 
 ```bash
-npx base44@latestfunctions deploy
+npx base44@latest functions deploy
 ```
 
 ## Authentication
@@ -29,7 +29,7 @@ npx base44@latestfunctions deploy
 ## Output
 
 ```bash
-$ npx base44@latestfunctions deploy
+$ npx base44@latest functions deploy
 
 Found 2 functions to deploy
 Deploying functions to Base44...
@@ -51,13 +51,13 @@ The deploy operation synchronizes your local functions with Base44:
 
 If no functions are found in your project:
 ```bash
-$ npx base44@latestfunctions deploy
+$ npx base44@latest functions deploy
 No functions found. Create functions in the 'functions' directory.
 ```
 
 If a function has configuration errors:
 ```bash
-$ npx base44@latestfunctions deploy
+$ npx base44@latest functions deploy
 Function deployment errors:
 'my-function' function: Entry point cannot be empty
 ```

--- a/skills/base44-cli/references/link.md
+++ b/skills/base44-cli/references/link.md
@@ -6,14 +6,14 @@ Links an existing local Base44 project to a Base44 app in the cloud. Use this wh
 
 | Scenario | Command |
 |----------|---------|
-| Starting fresh, no `base44/` folder | `npx base44@latestcreate` |
-| Have `base44/config.jsonc` but no `.app.jsonc` | `npx base44@latestlink` |
+| Starting fresh, no `base44/` folder | `npx base44@latest create` |
+| Have `base44/config.jsonc` but no `.app.jsonc` | `npx base44@latest link` |
 | Project already linked (has `.app.jsonc`) | Already done, use `deploy` |
 
 ## Syntax
 
 ```bash
-npx base44@latestlink [options]
+npx base44@latest link [options]
 ```
 
 ## Options
@@ -31,33 +31,33 @@ For CI/CD or agent use:
 
 **Create a new project:**
 ```bash
-npx base44@latestlink --create --name my-app
+npx base44@latest link --create --name my-app
 ```
 
 **Link to an existing project:**
 ```bash
-npx base44@latestlink --projectId <project-id>
+npx base44@latest link --projectId <project-id>
 ```
 
-WRONG: `npx base44@latestlink --create` (missing --name)
-WRONG: `npx base44@latestlink --create --projectId <id>` (cannot use both)
-RIGHT: `npx base44@latestlink --create --name my-app`
-RIGHT: `npx base44@latestlink --projectId <id>`
+WRONG: `npx base44@latest link --create` (missing --name)
+WRONG: `npx base44@latest link --create --projectId <id>` (cannot use both)
+RIGHT: `npx base44@latest link --create --name my-app`
+RIGHT: `npx base44@latest link --projectId <id>`
 
 ## Examples
 
 ```bash
 # Interactive mode - prompts for project details
-npx base44@latestlink
+npx base44@latest link
 
 # Non-interactive - create and link in one step
-npx base44@latestlink --create --name my-app
+npx base44@latest link --create --name my-app
 
 # With description
-npx base44@latestlink --create --name my-app --description "My awesome app"
+npx base44@latest link --create --name my-app --description "My awesome app"
 
 # Link to a specific existing project by ID
-npx base44@latestlink --projectId abc123
+npx base44@latest link --projectId abc123
 ```
 
 ## What It Does
@@ -73,9 +73,9 @@ npx base44@latestlink --projectId abc123
 
 - Must have `base44/config.jsonc` in the project
 - Must NOT have `base44/.app.jsonc` (use `deploy` if already linked)
-- Must be authenticated (run `npx base44@latestlogin` first)
+- Must be authenticated (run `npx base44@latest login` first)
 
 ## Notes
 
-- After linking, you can deploy resources with `npx base44@latestdeploy`
+- After linking, you can deploy resources with `npx base44@latest deploy`
 - The `.app.jsonc` file should be git-ignored (contains your app ID)

--- a/skills/base44-cli/references/link.md
+++ b/skills/base44-cli/references/link.md
@@ -6,14 +6,14 @@ Links an existing local Base44 project to a Base44 app in the cloud. Use this wh
 
 | Scenario | Command |
 |----------|---------|
-| Starting fresh, no `base44/` folder | `npx base44 create` |
-| Have `base44/config.jsonc` but no `.app.jsonc` | `npx base44 link` |
+| Starting fresh, no `base44/` folder | `npx base44@latestcreate` |
+| Have `base44/config.jsonc` but no `.app.jsonc` | `npx base44@latestlink` |
 | Project already linked (has `.app.jsonc`) | Already done, use `deploy` |
 
 ## Syntax
 
 ```bash
-npx base44 link [options]
+npx base44@latestlink [options]
 ```
 
 ## Options
@@ -31,33 +31,33 @@ For CI/CD or agent use:
 
 **Create a new project:**
 ```bash
-npx base44 link --create --name my-app
+npx base44@latestlink --create --name my-app
 ```
 
 **Link to an existing project:**
 ```bash
-npx base44 link --projectId <project-id>
+npx base44@latestlink --projectId <project-id>
 ```
 
-WRONG: `npx base44 link --create` (missing --name)
-WRONG: `npx base44 link --create --projectId <id>` (cannot use both)
-RIGHT: `npx base44 link --create --name my-app`
-RIGHT: `npx base44 link --projectId <id>`
+WRONG: `npx base44@latestlink --create` (missing --name)
+WRONG: `npx base44@latestlink --create --projectId <id>` (cannot use both)
+RIGHT: `npx base44@latestlink --create --name my-app`
+RIGHT: `npx base44@latestlink --projectId <id>`
 
 ## Examples
 
 ```bash
 # Interactive mode - prompts for project details
-npx base44 link
+npx base44@latestlink
 
 # Non-interactive - create and link in one step
-npx base44 link --create --name my-app
+npx base44@latestlink --create --name my-app
 
 # With description
-npx base44 link --create --name my-app --description "My awesome app"
+npx base44@latestlink --create --name my-app --description "My awesome app"
 
 # Link to a specific existing project by ID
-npx base44 link --projectId abc123
+npx base44@latestlink --projectId abc123
 ```
 
 ## What It Does
@@ -73,9 +73,9 @@ npx base44 link --projectId abc123
 
 - Must have `base44/config.jsonc` in the project
 - Must NOT have `base44/.app.jsonc` (use `deploy` if already linked)
-- Must be authenticated (run `npx base44 login` first)
+- Must be authenticated (run `npx base44@latestlogin` first)
 
 ## Notes
 
-- After linking, you can deploy resources with `npx base44 deploy`
+- After linking, you can deploy resources with `npx base44@latestdeploy`
 - The `.app.jsonc` file should be git-ignored (contains your app ID)

--- a/skills/base44-cli/references/site-deploy.md
+++ b/skills/base44-cli/references/site-deploy.md
@@ -18,7 +18,7 @@ Deploy built site files to Base44 hosting.
 ## Syntax
 
 ```bash
-npx base44 site deploy [options]
+npx base44@latestsite deploy [options]
 ```
 
 ## Options
@@ -30,7 +30,7 @@ npx base44 site deploy [options]
 Use `-y` flag for non-interactive/automated deployments:
 
 ```bash
-npx base44 site deploy -y
+npx base44@latestsite deploy -y
 ```
 
 ## Authentication
@@ -56,7 +56,7 @@ npx base44 site deploy -y
 ## Interactive Flow
 
 ```bash
-$ npx base44 site deploy
+$ npx base44@latestsite deploy
 
 Deploy site from ./dist? (yes/no) yes
 
@@ -76,7 +76,7 @@ Visit your site at: https://my-app.base44.app
 npm run build
 
 # 2. Deploy to Base44
-npx base44 site deploy
+npx base44@latestsite deploy
 ```
 
 ## Configuration
@@ -92,7 +92,7 @@ The `site.outputDirectory` in your project configuration should point to where y
 
 If site configuration is missing:
 ```bash
-$ npx base44 site deploy
+$ npx base44@latestsite deploy
 Error: No site configuration found in project
 ```
 

--- a/skills/base44-cli/references/site-deploy.md
+++ b/skills/base44-cli/references/site-deploy.md
@@ -18,7 +18,7 @@ Deploy built site files to Base44 hosting.
 ## Syntax
 
 ```bash
-npx base44@latestsite deploy [options]
+npx base44@latest site deploy [options]
 ```
 
 ## Options
@@ -30,7 +30,7 @@ npx base44@latestsite deploy [options]
 Use `-y` flag for non-interactive/automated deployments:
 
 ```bash
-npx base44@latestsite deploy -y
+npx base44@latest site deploy -y
 ```
 
 ## Authentication
@@ -56,7 +56,7 @@ npx base44@latestsite deploy -y
 ## Interactive Flow
 
 ```bash
-$ npx base44@latestsite deploy
+$ npx base44@latest site deploy
 
 Deploy site from ./dist? (yes/no) yes
 
@@ -76,7 +76,7 @@ Visit your site at: https://my-app.base44.app
 npm run build
 
 # 2. Deploy to Base44
-npx base44@latestsite deploy
+npx base44@latest site deploy
 ```
 
 ## Configuration
@@ -92,7 +92,7 @@ The `site.outputDirectory` in your project configuration should point to where y
 
 If site configuration is missing:
 ```bash
-$ npx base44@latestsite deploy
+$ npx base44@latest site deploy
 Error: No site configuration found in project
 ```
 

--- a/skills/base44-cli/references/site-open.md
+++ b/skills/base44-cli/references/site-open.md
@@ -5,7 +5,7 @@ Opens the published site in your default web browser.
 ## Syntax
 
 ```bash
-npx base44@latestsite open
+npx base44@latest site open
 ```
 
 ## Authentication
@@ -21,7 +21,7 @@ npx base44@latestsite open
 ## Example
 
 ```bash
-$ npx base44@latestsite open
+$ npx base44@latest site open
 
 Site opened at https://my-app.base44.app
 ```
@@ -29,7 +29,7 @@ Site opened at https://my-app.base44.app
 ## Requirements
 
 - Must be run from a linked Base44 project directory
-- Must be authenticated (run `npx base44@latestlogin` first)
+- Must be authenticated (run `npx base44@latest login` first)
 - Site must have been deployed at least once
 
 ## Notes

--- a/skills/base44-cli/references/site-open.md
+++ b/skills/base44-cli/references/site-open.md
@@ -5,7 +5,7 @@ Opens the published site in your default web browser.
 ## Syntax
 
 ```bash
-npx base44 site open
+npx base44@latestsite open
 ```
 
 ## Authentication
@@ -21,7 +21,7 @@ npx base44 site open
 ## Example
 
 ```bash
-$ npx base44 site open
+$ npx base44@latestsite open
 
 Site opened at https://my-app.base44.app
 ```
@@ -29,7 +29,7 @@ Site opened at https://my-app.base44.app
 ## Requirements
 
 - Must be run from a linked Base44 project directory
-- Must be authenticated (run `npx base44 login` first)
+- Must be authenticated (run `npx base44@latestlogin` first)
 - Site must have been deployed at least once
 
 ## Notes

--- a/skills/base44-cli/references/types-generate.md
+++ b/skills/base44-cli/references/types-generate.md
@@ -5,7 +5,7 @@ Generate TypeScript declaration file (`types.d.ts`) from project resources (enti
 ## Usage
 
 ```bash
-npx base44@latesttypes generate
+npx base44@latest types generate
 ```
 
 ## What It Does

--- a/skills/base44-cli/references/types-generate.md
+++ b/skills/base44-cli/references/types-generate.md
@@ -5,7 +5,7 @@ Generate TypeScript declaration file (`types.d.ts`) from project resources (enti
 ## Usage
 
 ```bash
-npx base44 types generate
+npx base44@latesttypes generate
 ```
 
 ## What It Does

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -36,7 +36,7 @@ This skill activates on ANY mention of "base44" or when a `base44/` folder exist
 - ❌ Initializing new Base44 projects (use `base44-cli` instead)
 - ❌ Empty directories without Base44 configuration
 - ❌ When user says "create a new Base44 project/app/site" and no project exists
-- ❌ CLI commands like `npx base44@latestcreate`, `npx base44@latestdeploy`, `npx base44@latestlogin` (use `base44-cli`)
+- ❌ CLI commands like `npx base44@latest create`, `npx base44@latest deploy`, `npx base44@latest login` (use `base44-cli`)
 
 **Skill Dependencies:**
 - `base44-sdk` assumes a Base44 project is **already initialized**

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -36,7 +36,7 @@ This skill activates on ANY mention of "base44" or when a `base44/` folder exist
 - ❌ Initializing new Base44 projects (use `base44-cli` instead)
 - ❌ Empty directories without Base44 configuration
 - ❌ When user says "create a new Base44 project/app/site" and no project exists
-- ❌ CLI commands like `npx base44 create`, `npx base44 deploy`, `npx base44 login` (use `base44-cli`)
+- ❌ CLI commands like `npx base44@latestcreate`, `npx base44@latestdeploy`, `npx base44@latestlogin` (use `base44-cli`)
 
 **Skill Dependencies:**
 - `base44-sdk` assumes a Base44 project is **already initialized**


### PR DESCRIPTION
## Summary

Updates all Base44 CLI skill documentation to use `npx base44@latest` instead of `npx base44`, ensuring agents always run the most recent version of the Base44 CLI.

## Changes

- Replace all occurrences of 'npx base44' with 'npx base44@latest' across 24 files
- Add prominent instructions in SKILL.md about always using @latest
- Update authentication check examples
- Update all command examples in Quick Start and Common Workflows

Fixes #81

🤖 Generated with [Claude Code](https://claude.ai/code)