### PR TITLE
docs(sdk): add REST API reference for direct entity access

### DIFF
--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -200,6 +200,9 @@ const base44 = createClient({
 - Import data from file → `entities.importEntities()`
 - Realtime updates → `entities.EntityName.subscribe()`
 
+**Direct API access?**
+- REST API for migrations, backfills, debugging → See [rest-api.md](references/rest-api.md)
+
 **User management?**
 - Login/register/logout → `auth`
 - Get current user → `auth.me()`

--- a/skills/base44-sdk/references/entities.md
+++ b/skills/base44-sdk/references/entities.md
@@ -13,6 +13,8 @@ CRUD operations on data models. Access via `base44.entities.EntityName.method()`
 
 **Note:** The maximum limit for `list()` and `filter()` is 5,000 items per request.
 
+**Tip:** For data migrations or bulk operations from local scripts, you can also use the [REST API](rest-api.md) directly.
+
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `create(data)` | `Promise<T>` | Create one record |

--- a/skills/base44-sdk/references/rest-api.md
+++ b/skills/base44-sdk/references/rest-api.md
@@ -1,0 +1,66 @@
+# REST API (Direct Entity Access)
+
+Entity data can be accessed directly via HTTP, useful for data migrations, backfills, debugging, or when the SDK isn't available.
+
+## Base URL
+
+```
+https://app.base44.com/api/apps/{appId}/entities/{EntityName}
+```
+
+## Authentication
+
+Include the API key in the request header:
+
+```bash
+-H "api_key: YOUR_API_KEY"
+```
+
+API keys can be found in project secrets (`npx base44 secrets list`).
+
+## Query Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `sort` | Sort field (prefix `-` for descending) | `sort=-created_date` |
+| `limit` | Max records to return (max 5000) | `limit=100` |
+| `skip` | Offset for pagination | `skip=100` |
+
+## Examples
+
+### List records
+```bash
+curl -s "https://app.base44.com/api/apps/{appId}/entities/Task?sort=-created_date&limit=10" \
+  -H "api_key: YOUR_API_KEY"
+```
+
+### Paginate through all records
+```bash
+# Page 1
+curl -s "...?limit=1000&skip=0" -H "api_key: ..."
+# Page 2
+curl -s "...?limit=1000&skip=1000" -H "api_key: ..."
+```
+
+### Create a record
+```bash
+curl -s -X POST "https://app.base44.com/api/apps/{appId}/entities/Task" \
+  -H "api_key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "New task", "status": "pending"}'
+```
+
+### Update a record
+```bash
+curl -s -X PUT "https://app.base44.com/api/apps/{appId}/entities/Task/{recordId}" \
+  -H "api_key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "done"}'
+```
+
+## When to Use
+
+- **Data migrations and backfills** — processing large datasets from local scripts
+- **Debugging** — inspecting entity data when the dashboard isn't enough
+- **CI/CD pipelines** — seeding test data or validating deployments
+- **Backend function limitations** — when SDK calls in Deno hit response size limits


### PR DESCRIPTION
## Summary
- New `skills/base44-sdk/references/rest-api.md` documenting the REST API for direct entity access
- Updated SKILL.md with "Direct API access?" in the Module Selection section
- Added tip in entities.md pointing to REST API for migrations

## Motivation
During b44emoji development, the SDK's `list()` calls in Deno backend functions failed with decompression errors for large collections. The REST API (via curl) worked perfectly but was completely undocumented. We discovered the URL pattern and auth headers by trial and error. This reference makes it a first-class access method.

## Test plan
- [ ] Verify REST API URL format matches actual Base44 API
- [ ] Verify links from SKILL.md and entities.md resolve correctly
- [ ] Test documented curl examples against a real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)