### PR TITLE
docs: add logs command reference and backend function best practices

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -387,6 +387,25 @@ Run one-off scripts against your app with the Base44 SDK pre-authenticated. Use 
 
 **SPA only**: Base44 hosting supports Single Page Applications with a single `index.html` entry point. All routes are served from `index.html` (client-side routing).
 
+### Logs
+
+| Command | Description |
+|---------|-------------|
+| `base44 logs [function-name]` | View function execution logs |
+
+**Flags:**
+- `--function <name>` — Filter by function name (comma-separated for multiple)
+- `--level <info|warning|error|debug>` — Filter by log level
+- `--since <ISO-datetime>` — Show logs after this time
+- `--until <ISO-datetime>` — Show logs before this time
+- `--limit <N>` — Results per page (1-1000)
+- `--order <asc|desc>` — Sort order (default: desc)
+
+**Example:**
+```bash
+npx base44 logs --function my-function --level error --since 2024-03-01T00:00:00Z
+```
+
 ## Quick Start
 
 1. Install the CLI in your project:

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -391,7 +391,7 @@ Run one-off scripts against your app with the Base44 SDK pre-authenticated. Use 
 
 | Command | Description |
 |---------|-------------|
-| `base44 logs [function-name]` | View function execution logs |
+| `base44 logs [options]` | View function execution logs |
 
 **Flags:**
 - `--function <name>` — Filter by function name (comma-separated for multiple)
@@ -405,6 +405,8 @@ Run one-off scripts against your app with the Base44 SDK pre-authenticated. Use 
 ```bash
 npx base44 logs --function my-function --level error --since 2024-03-01T00:00:00Z
 ```
+
+For detailed logs documentation, see the base44-troubleshooter skill.
 
 ## Quick Start
 

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -227,6 +227,54 @@ const base44 = createClient({
 - Track custom events → `analytics.track()`
 - Log page views/activity → `appLogs.logUserInApp()`
 
+## Backend Function Best Practices
+
+### Avoid scanning large collections
+
+Backend functions run in Deno with limited memory. Fetching large entity collections with `list()` may fail for collections with thousands of records.
+
+**Instead of scan-and-aggregate:**
+```javascript
+// ❌ Fragile — fails as collection grows
+const allUsages = await base44.entities.Usage.list("-created_date", 5000);
+const counts = {};
+for (const u of allUsages) { counts[u.user_id] = (counts[u.user_id] || 0) + 1; }
+```
+
+**Use incremental pre-computed stats:**
+```javascript
+// ✅ Update a stats record on each new event (via entity hook automation)
+const stats = await base44.entities.UserStats.filter({ user_id: userId }, null, 1);
+if (stats.length > 0) {
+  await base44.entities.UserStats.update(stats[0].id, { total: stats[0].total + 1 });
+}
+```
+
+### Use filter() with specific conditions
+
+`filter()` with targeted conditions returns smaller result sets and works reliably:
+```javascript
+// ✅ Small, targeted query
+const userStats = await base44.entities.UserStats.filter({ user_id: "U123" }, null, 1);
+```
+
+### Use pagination for large reads
+
+When you need to process many records, paginate with `skip`:
+```javascript
+let skip = 0;
+while (true) {
+  const batch = await base44.entities.Task.list("-created_date", 100, skip);
+  if (batch.length === 0) break;
+  // process batch
+  skip += 100;
+}
+```
+
+### Use the REST API for data migrations
+
+For one-time backfills or large data operations, use the [REST API](references/rest-api.md) from a local script instead of a backend function.
+
 ## Common Patterns
 
 ### Filter and Sort Data

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -273,7 +273,7 @@ while (true) {
 
 ### Use the REST API for data migrations
 
-For one-time backfills or large data operations, use the [REST API](references/rest-api.md) from a local script instead of a backend function.
+For one-time backfills or large data operations, use the Base44 REST API (`https://app.base44.com/api/apps/{appId}/entities/{EntityName}`) from a local script instead of a backend function.
 
 ## Common Patterns
 

--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -15,7 +15,7 @@ npx base44 logs [options]
 | `--function <names>` | Filter by function name(s), comma-separated. If omitted, fetches logs for all project functions | No |
 | `--since <datetime>` | Show logs from this time (ISO format) | No |
 | `--until <datetime>` | Show logs until this time (ISO format) | No |
-| `--level <level>` | Filter by log level: `log`, `info`, `warn`, `error`, `debug` | No |
+| `--level <level>` | Filter by log level: `info`, `warning`, `error`, `debug` | No |
 | `-n, --limit <n>` | Number of results to return (1-1000, default: 50) | No |
 | `--order <order>` | Sort order: `asc` or `desc` (default: `desc`) | No |
 


### PR DESCRIPTION
## Summary
- Added logs command reference to CLI skill (correct syntax with --function flag)
- Added "Backend Function Best Practices" section to SDK skill covering:
  - Avoid scanning large collections with list()
  - Use filter() with specific conditions
  - Use pagination with skip
  - Use REST API for data migrations
- Fixed pre-existing bug: wrong log level values in troubleshooter docs (`log` and `warn` changed to `warning`)
- Added cross-reference to base44-troubleshooter for detailed logs docs

## Motivation
During b44emoji development, we used bare `npx base44 logs` and got interleaved output from all functions, not realizing `--function` filtering existed. We also hit response size limits in Deno backend functions and had to redesign from scratch. These docs would have saved significant time.

## Test plan
- [ ] Verify logs command flags match actual CLI implementation
- [ ] Verify log level values match `LogLevelSchema` in CLI source
- [ ] Check REST API inline URL is correct
- [ ] Verify troubleshooter cross-reference is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)