### PR TITLE
docs(base44-cli): document the scaffold command

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -200,6 +200,7 @@ npx base44 <command>
 | Command | Description | Reference |
 |---------|-------------|-----------|
 | `base44 create` | Create a new Base44 project from a template | [create.md](references/create.md) ⚠️ **MUST READ** |
+| `base44 scaffold` | Scaffold a local project for an existing Base44 app (by app ID) | [scaffold.md](references/scaffold.md) |
 | `base44 link` | Link an existing local project to Base44 | [link.md](references/link.md) |
 | `base44 eject` | Download the code for an existing Base44 project | [eject.md](references/eject.md) |
 | `base44 dashboard open` | Open the app dashboard in your browser | [dashboard.md](references/dashboard.md) |

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -17,13 +17,16 @@ This skill activates on ANY mention of "base44" or when a `base44/` folder exist
 
 **Your first action MUST be:**
 1. Check if `base44/config.jsonc` exists in the current directory
-2. If **NO** (new project scenario):
-   - This skill (base44-cli) handles the request
-   - Guide user through project initialization
-   - Do NOT activate base44-sdk yet
-3. If **YES** (existing project scenario):
+2. If **YES** (existing project scenario):
    - Transfer to base44-sdk skill for implementation
    - This skill only handles CLI commands (login, deploy, entities push)
+3. If **NO**, decide between two initialization paths:
+   - **Provisioned app** — the Base44 app already exists because it was just provisioned through a Stripe Projects / projects.dev flow, OR `BASE44_APP_ID` (or `BASE44_PROJECTS_BASE44_APP_ID`) is present in the environment or a `.env`/`.env.local` file:
+     - Run `npx base44 scaffold` to set up local files for that **existing** app
+     - **DO NOT run `npx base44 create`** — that creates a second, duplicate app. See [scaffold.md](references/scaffold.md).
+   - **New project** — no app exists yet and none was provisioned:
+     - This skill (base44-cli) handles the request; guide the user through `npx base44 create`
+     - Do NOT activate base44-sdk yet
 
 ## Critical: Local Installation Only
 
@@ -59,6 +62,8 @@ RIGHT: `npx base44 login`
 
 **This check is mandatory and must happen before executing any other Base44 CLI commands.**
 
+**Provisioned via Stripe Projects / projects.dev?** When the app was provisioned through that flow, the CLI seeds authentication from the `BASE44_ACCESS_TOKEN` / `BASE44_REFRESH_TOKEN` environment variables it injects (the `BASE44_PROJECTS_*`-prefixed names are normalized automatically). In that case `npx base44 whoami` already succeeds and you do **not** need an interactive `npx base44 login`.
+
 ## Overview
 
 The Base44 CLI provides command-line tools for authentication, creating projects, managing entities, and deploying Base44 applications. It is framework-agnostic and works with popular frontend frameworks like Vite, Next.js, and Create React App, Svelte, Vue, and more.
@@ -68,6 +73,7 @@ The Base44 CLI provides command-line tools for authentication, creating projects
 **Use base44-cli when:**
 - Creating a **NEW** Base44 project from scratch
 - Initializing a project in an empty directory
+- Setting up local files for an **existing** app that was provisioned externally (e.g., through a Stripe Projects / projects.dev flow) → use `scaffold`
 - Directory is missing `base44/config.jsonc`
 - User mentions: "create a new project", "initialize project", "setup a project", "start a new Base44 app"
 - Deploying, pushing entities, or authenticating via CLI
@@ -88,10 +94,12 @@ The Base44 CLI provides command-line tools for authentication, creating projects
 **State Check Logic:**
 Before selecting a skill, check:
 - IF (user mentions "create/build app" OR "make a project"):
-  - IF (directory is empty OR no `base44/config.jsonc` exists):
-    → Use **base44-cli** (project initialization needed)
-  - ELSE:
+  - IF (`base44/config.jsonc` exists):
     → Use **base44-sdk** (project exists, build features)
+  - ELSE IF (app was provisioned externally — `BASE44_APP_ID`/`BASE44_PROJECTS_BASE44_APP_ID` set, or a Stripe Projects / projects.dev flow just ran):
+    → Use **base44-cli** → `npx base44 scaffold` (set up local files for the existing app; do NOT `create`)
+  - ELSE:
+    → Use **base44-cli** → `npx base44 create` (new project initialization needed)
 
 ## Project Structure
 

--- a/skills/base44-cli/references/scaffold.md
+++ b/skills/base44-cli/references/scaffold.md
@@ -1,0 +1,60 @@
+# base44 scaffold
+
+Scaffolds a local project for an **existing** Base44 app. Use this when you already have a Base44 app (you know its app ID) and want to set up the local project files to work with it. Runs fully non-interactively, so it is safe for agents and CI.
+
+## Critical: When to Use Scaffold vs Create vs Link
+
+| Scenario | Command |
+|----------|---------|
+| Starting fresh, want a NEW Base44 app + project from a template | `npx base44 create` |
+| You already have a Base44 app (by ID) and want local files for it | `npx base44 scaffold` |
+| Have a local `base44/config.jsonc` but no `.app.jsonc` | `npx base44 link` |
+
+## Syntax
+
+```bash
+npx base44 scaffold [name] [options]
+```
+
+Scaffolds into the **current directory**.
+
+## Arguments & Options
+
+| Argument/Option | Description | Required |
+|-----------------|-------------|----------|
+| `name` | Project name (positional). Defaults to the current directory name. | No |
+| `--app-id <id>` | Existing Base44 app ID. Falls back to the `BASE44_APP_ID` environment variable. | Yes* |
+| `--no-skills` | Skip AI agent skills installation (skills are installed by default) | No |
+
+*The app ID is required: provide it via `--app-id` or the `BASE44_APP_ID` environment variable. If neither is set, the command fails.
+
+## Examples
+
+```bash
+# Scaffold the current directory for an existing app
+npx base44 scaffold --app-id app_123
+
+# Scaffold the current directory with an explicit project name
+npx base44 scaffold my-app --app-id app_123
+
+# Provide the app ID via environment variable instead of the flag
+BASE44_APP_ID=app_123 npx base44 scaffold
+
+# Scaffold without installing AI agent skills
+npx base44 scaffold --app-id app_123 --no-skills
+```
+
+## What It Does
+
+1. Resolves the app ID from `--app-id` or the `BASE44_APP_ID` environment variable
+2. Applies the `backend-only` template to the current directory
+3. Registers the project files against the existing app and writes `base44/.app.jsonc` with the app ID
+4. Installs AI agent skills (unless `--no-skills` is passed)
+
+## Notes
+
+- **Template:** Always uses the `backend-only` template (Base44 configuration only — no frontend is generated).
+- **Non-interactive:** Never prompts. It does **not** push entities or deploy the site. Use `npx base44 deploy` afterward to push resources.
+- **Existing app only:** Unlike `create`, this does not create a new Base44 app — it links local files to the app ID you supply.
+- **Authentication:** Requires you to be authenticated (run `npx base44 login` first).
+- The `.app.jsonc` file should be git-ignored (it contains your app ID).

--- a/skills/base44-cli/references/scaffold.md
+++ b/skills/base44-cli/references/scaffold.md
@@ -51,6 +51,23 @@ npx base44 scaffold --app-id app_123 --no-skills
 3. Registers the project files against the existing app and writes `base44/.app.jsonc` with the app ID
 4. Installs AI agent skills (unless `--no-skills` is passed)
 
+## Provisioning Handoff (Stripe Projects / projects.dev)
+
+`scaffold` is the command to run after a Base44 app is provisioned through a Stripe Projects / projects.dev flow. **Use `scaffold`, not `create`** — the app already exists, so `create` would create a duplicate.
+
+When Base44 is provisioned that way, the credentials are injected into the environment under a `BASE44_PROJECTS_` prefix (e.g. `BASE44_PROJECTS_BASE44_APP_ID`, `BASE44_PROJECTS_BASE44_ACCESS_TOKEN`, `BASE44_PROJECTS_BASE44_REFRESH_TOKEN`). The CLI automatically normalizes these to the bare names it uses (`BASE44_APP_ID`, `BASE44_ACCESS_TOKEN`, …). As a result:
+
+- **App ID** is resolved from `BASE44_APP_ID` automatically — no `--app-id` flag needed.
+- **Authentication** is seeded from `BASE44_ACCESS_TOKEN` / `BASE44_REFRESH_TOKEN` — no interactive `npx base44 login` needed.
+
+So the entire post-provisioning step is just:
+
+```bash
+npx base44 scaffold
+```
+
+Run it from the directory where you want the project files. After scaffolding, push resources with `npx base44 deploy`.
+
 ## Notes
 
 - **Template:** Always uses the `backend-only` template (Base44 configuration only — no frontend is generated).


### PR DESCRIPTION
## Summary

Documents the new `base44 scaffold` command (present as of CLI v0.0.55) and wires it into the skill's project-initialization guidance, including the **Stripe Projects / projects.dev provisioning handoff**.

`scaffold` sets up local project files for an **existing** Base44 app (by app ID), using the `backend-only` template, fully non-interactively — distinct from `create` (creates a new app) and `link` (links an existing local config).

## Changes

### New command reference
- **`skills/base44-cli/references/scaffold.md`** (new) — syntax, options, examples, a scaffold-vs-create-vs-link comparison, and a **Provisioning Handoff** section.

### Guide agents to use scaffold after provisioning
When a Base44 app is provisioned through a Stripe Projects / projects.dev flow, the app already exists and its credentials are injected as `BASE44_PROJECTS_*` env vars, which the CLI normalizes to the bare `BASE44_*` names. The agent should then run `npx base44 scaffold` (no flags) — **not** `create`, which would duplicate the app.

- **`skills/base44-cli/SKILL.md`**: register scaffold in the command table; add a provisioned-app branch to the IMMEDIATE ACTION decision tree and State Check Logic; note env-seeded auth (no interactive login); mention scaffold in the "when to use base44-cli" list.

## Verified mechanics (from the CLI `main`)
- `scaffold.ts`: `appId = options.appId ?? process.env.BASE44_APP_ID`
- `core/utils/env.ts` normalizeBase44Env(): `BASE44_PROJECTS_*` → bare `BASE44_*`
- `core/auth/config.ts` seedAuthFromEnv(): auth from `BASE44_ACCESS_TOKEN`/`BASE44_REFRESH_TOKEN`

## Notes
Scoped to documenting `scaffold` only — does **not** bump `CLI_VERSION` or `sourcePackage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)