### PR TITLE
[TEST] skill-sync Slack notifier smoke test — ignore, will be closed

### DIFF
--- a/.github/notify-smoke-test.md
+++ b/.github/notify-smoke-test.md
@@ -1,0 +1,6 @@
+# Notifier smoke test
+
+Temporary file to give a throwaway PR a diff, so we can verify the
+Slack skill-sync notifier fires on the `auto-skill-update` label.
+
+Safe to delete — this branch and PR will be closed right after the test.


### PR DESCRIPTION
Throwaway PR to verify the `auto-skill-update` → Slack notifier wiring end-to-end. Will be closed and the branch deleted right after the notifier posts. Please ignore.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uXhc3bU6WHd6Re843MP8W)_