### PR TITLE
docs(base44-cli): custom domain commands

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -425,6 +425,47 @@ Run one-off scripts against your app with the Base44 SDK pre-authenticated. Use 
 
 **SPA only**: Base44 hosting supports Single Page Applications with a single `index.html` entry point. All routes are served from `index.html` (client-side routing).
 
+### Custom Domains
+
+Connect your own domain (e.g. `app.example.com`) to a deployed full-stack app. Custom domains use Cloudflare-for-SaaS custom hostnames: the CLI registers the hostname, and you point your domain at Base44 with a single **CNAME** record. TLS certificates are then **issued and renewed automatically** — you never manage a certificate.
+
+| Command | Description |
+|---------|-------------|
+| `base44 domains add <hostname> [--wait]` | Connect a custom domain. Prints the exact CNAME record to add and the current status. |
+| `base44 domains list` | List connected domains with their live hostname + certificate status. |
+| `base44 domains remove <hostname> [-y]` | Disconnect a custom domain (removes the hostname, route, and record). |
+
+**The one manual step — add the CNAME record.** After `domains add`, the CLI prints a DNS record like:
+
+```
+Add this DNS record:
+  CNAME  app.example.com  →  <cname-target>
+Status: pending (SSL: pending_validation)
+```
+
+Create that `CNAME` record with your DNS provider, pointing your hostname at the printed target. Once it resolves, Cloudflare validates ownership and issues the TLS certificate automatically; the domain then serves your app's current production deployment.
+
+**`--wait`.** `base44 domains add <hostname> --wait` polls until both the hostname and its TLS certificate are active (2s interval), showing a spinner with the live status. Add the CNAME record first (or during the wait) so it can complete; otherwise it times out waiting for the DNS record.
+
+**Notes:**
+- If the app has no production deployment yet, the domain is still connected but won't serve until you `npx base44 deploy` and promote a deployment to production (`base44 promote`).
+- `npx base44 domains list` re-fetches live status from Cloudflare, so re-run it to watch a pending domain flip to active.
+- Custom domains attach to the app's **production** deployment; they follow promote/rollback automatically.
+
+```bash
+# Connect a domain and print the CNAME to add
+npx base44 domains add app.example.com
+
+# ...or connect and wait until the certificate is active
+npx base44 domains add app.example.com --wait
+
+# Check status of all connected domains
+npx base44 domains list
+
+# Disconnect a domain (skip the confirmation prompt with -y)
+npx base44 domains remove app.example.com -y
+```
+
 ## Quick Start
 
 1. Install the CLI in your project:

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -466,6 +466,32 @@ npx base44 domains list
 npx base44 domains remove app.example.com -y
 ```
 
+### App Slug
+
+Every app has a **slug** — its public subdomain on Base44 (`https://<slug>.base44.app`). For full-stack apps the production URL follows the slug, so changing it moves where the app is served. Slugs are auto-generated from the app name + id; set a custom one for a cleaner URL.
+
+| Command | Description |
+|---------|-------------|
+| `base44 slug` | Show the app's current slug and its public URL. |
+| `base44 slug set <slug>` | Set a custom slug. Prints old → new slug and the resulting production URL. |
+| `base44 slug reset` | Reset to the auto-generated slug (derived from the app name + id). Prints the new slug. |
+
+**Notes:**
+- Slug format: 3–50 characters — lowercase letters, numbers, and hyphens. Reserved words (`api`, `admin`, `login`, …) are rejected.
+- If the slug is already taken, the error includes available alternative suggestions to pick from.
+- Changing the slug takes effect immediately: previously shared links to the old subdomain stop working. Custom domains are unaffected.
+
+```bash
+# Show the current slug and public URL
+npx base44 slug
+
+# Change the slug (app now serves at https://my-cool-app.base44.app)
+npx base44 slug set my-cool-app
+
+# Reset to the auto-generated slug
+npx base44 slug reset
+```
+
 ## Quick Start
 
 1. Install the CLI in your project:

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -321,6 +321,8 @@ Agents are conversational AI assistants that can interact with users, access you
     // Backend function tool - gives agent access to a function
     { "function_name": "send_email", "description": "Send an email notification" }
   ],
+  // Optional: pin an LLM model. Omit to use the platform default (recommended). See "Agent models" below.
+  "model": "claude_sonnet_4_6",
   "whatsapp_greeting": "Hello! How can I help you today?"
 }
 ```
@@ -331,11 +333,17 @@ Agents are conversational AI assistants that can interact with users, access you
 - Invalid: `Support-Agent`, `OrderBot`
 
 **Required fields:** `name`, `description`, `instructions`
-**Optional fields:** `tool_configs` (defaults to `[]`), `whatsapp_greeting`
+**Optional fields:** `tool_configs` (defaults to `[]`), `model`, `whatsapp_greeting`
 
 **Tool config types:**
 - **Entity tools**: `entity_name` + `allowed_operations` (array of: `read`, `create`, `update`, `delete`)
 - **Backend function tools**: `function_name` + `description`
+
+#### Agent models
+
+- **Omit `model` to use the platform default (recommended).** Empty or absent `model` is always valid.
+- To pin a model, use one of the supported ids: `automatic`, `gpt_5_mini`, `gemini_3_flash`, `gpt_5_4`, `gpt_5_5`, `gemini_3_1_pro`, `claude_sonnet_4_6`, `claude_opus_4_6`, `claude_opus_4_7`, `claude_opus_4_8`. Full provider strings (e.g. `anthropic/claude-opus-4-7`) are accepted only for models the platform currently serves.
+- **Deploy validates model ids.** `base44 deploy` / `base44 agents push` fail with a 400 listing the currently supported ids when `model` is unknown or stale — e.g. a dated vendor id like `anthropic/claude-sonnet-4-20250514`. Never guess or copy model ids from memory; if a push is rejected, use an id from the error message or omit `model`.
 
 ### Connector Management
 

--- a/skills/base44-cli/references/agents-push.md
+++ b/skills/base44-cli/references/agents-push.md
@@ -79,6 +79,7 @@ Each agent file should be a `.jsonc` file in `base44/agents/` with this structur
     // Backend function tool - gives agent access to a function
     { "function_name": "send_email", "description": "Send an email notification" }
   ],
+  "model": "claude_sonnet_4_6",      // Optional: omit to use the platform default (recommended)
   "whatsapp_greeting": "Hello! How can I help you today?"  // Optional
 }
 ```
@@ -99,6 +100,7 @@ Each agent file should be a `.jsonc` file in `base44/agents/` with this structur
 - `description`: Required, minimum 1 character
 - `instructions`: Required, minimum 1 character
 - `tool_configs`: Optional, defaults to empty array
+- `model`: Optional, omit to use the platform default (recommended). If pinning, use a supported id (e.g. `claude_sonnet_4_6`, `gpt_5_5`, `gemini_3_1_pro`) — the push fails with a 400 listing the currently supported ids when the model is unknown or stale (e.g. `anthropic/claude-sonnet-4-20250514`); never guess model ids
 - `whatsapp_greeting`: Optional
 
 ### Common Mistake: Wrong tool_configs Format


### PR DESCRIPTION
## What

Documents the new `base44 domains` command family in the `base44-cli` skill (`skills/base44-cli/SKILL.md`), added as part of the full-stack hosting POC on Cloudflare Workers for Platforms.

New "Custom Domains" section under Site Management covers:
- `base44 domains add <hostname> [--wait]`, `base44 domains list`, `base44 domains remove <hostname> [-y]`
- The one manual step: adding the printed **CNAME** record pointing the hostname at the Base44 target
- `--wait` — polls (2s interval) until the hostname + TLS certificate are active
- TLS certificates are **issued and renewed automatically** once the CNAME resolves
- Notes: connecting before a production deployment exists, `list` re-fetching live status, and domains following promote/rollback

## Related

- CLI implementation: base44/cli#559 (`base44 domains add/list/remove`)
- Backend domains API: apper full-stack hosting PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvhQfqxACcq25XAQRpoSh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvhQfqxACcq25XAQRpoSh9)_