### PR TITLE
Tag @ef-app-infra in skill-sync Slack notification

### DIFF
--- a/.github/workflows/notify-slack-skill-sync.yml
+++ b/.github/workflows/notify-slack-skill-sync.yml
@@ -40,6 +40,6 @@ jobs:
             echo "::warning::SLACK_WEBHOOK_URL secret is not set — skipping Slack notification."
             exit 0
           fi
-          text=$(printf ':package: Skill-update PR needs a review: <%s|#%s — %s>' "${PR_URL}" "${PR_NUMBER}" "${PR_TITLE}")
+          text=$(printf ':package: Skill-update PR needs a review: <%s|#%s — %s> @ef-app-infra' "${PR_URL}" "${PR_NUMBER}" "${PR_TITLE}")
           jq -n --arg text "${text}" '{text: $text}' \
             | curl -sS --fail -X POST -H 'Content-type: application/json' --data @- "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
Appends `@ef-app-infra` to the Slack message posted when an auto-generated skill-sync PR opens, so the group is tagged.

Closes #133

The inside Claude bot couldn't push this itself — the change touches `.github/workflows/`, which the GitHub App token lacks the `workflows` scope to modify. This PR applies the one-line change directly.

### Note on Slack mention semantics
Plain text `@ef-app-infra` in an incoming-webhook payload renders as literal text, not a real notifying mention. Slack only turns `@name` into an actual ping when it's the internal ID form (`<!subteam^ID|@ef-app-infra>` for a user group). If a real ping is needed, share the group's Slack ID and it's a quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk7HSH6kwAryVdaBhvcM8k)_