### PR TITLE
docs(base44-cli): document base44/shared/ for cross-function shared code

### DIFF
--- a/skills/base44-cli/references/functions-create.md
+++ b/skills/base44-cli/references/functions-create.md
@@ -213,6 +213,26 @@ For more details on deploying, see [functions-deploy.md](functions-deploy.md).
 - Configure secrets via app dashboard for API keys
 - Make sure to handle errors gracefully and return appropriate HTTP status codes
 
+## Sharing Code Between Functions
+
+Place shared utilities in `base44/shared/` — the only directory outside a function folder that the CLI will upload.
+
+```
+base44/
+  shared/
+    response.ts    ← shared helpers
+  functions/
+    greet/
+      entry.ts     ← import { ok } from "../../shared/response.ts";
+    farewell/
+      entry.ts     ← import { ok } from "../../shared/response.ts";
+```
+
+**Rules:**
+- Shared files **must** live inside `base44/shared/` (or any subdirectory of `base44/`, but `shared/` is the convention).
+- Imports that escape past `base44/` (e.g. `../../../src/utils.ts`) are **blocked at deploy time** with an error — the file can't be uploaded and would fail at runtime anyway.
+- For external packages use `npm:` or `jsr:` specifiers, not relative paths.
+
 ## Common Mistakes
 
 | Wrong | Correct | Why |
@@ -221,3 +241,4 @@ For more details on deploying, see [functions-deploy.md](functions-deploy.md).
 | `base44/functions/entry.ts` | `base44/functions/my-function/entry.ts` | The function name comes from the subdirectory path |
 | `import { ... } from "@base44/sdk"` | `import { ... } from "npm:@base44/sdk"` | Deno requires `npm:` prefix for npm packages |
 | `MyFunction` or `myFunction` directory | `my-function` directory | Use kebab-case for directory names |
+| `import { x } from "../../../src/utils.ts"` | `import { x } from "../../shared/utils.ts"` | Imports outside `base44/` are blocked — move shared code to `base44/shared/` |

--- a/skills/base44-cli/references/functions-create.md
+++ b/skills/base44-cli/references/functions-create.md
@@ -1,6 +1,6 @@
 # Creating Functions
 
-Base44 functions are serverless backend functions that run on Deno. They are defined locally in your project and deployed to the Base44 backend.
+Base44 functions are serverless backend functions. They are defined locally in your project and deployed to the Base44 backend.
 
 ## Function Directory
 
@@ -43,12 +43,12 @@ The function name is the path from the functions root to that folder. For exampl
 
 Rules:
 - `entry.ts` or `entry.js` must be inside a named subfolder, not directly in `base44/functions/`
-- all `*.js`, `*.ts`, and `*.json` files under the function folder are included when deploying
+- all `*.js`, `*.ts`, `*.json`, and `*.jsonc` files under the function folder are included when deploying
 - function paths with a dot in any path segment are ignored
 
 ## Entry Point File
 
-Functions run on Deno and must export using `Deno.serve()`. Use `npm:` prefix for npm packages.
+Functions export a request handler using `Deno.serve()`. Use the `npm:` prefix to import npm packages.
 
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
@@ -73,7 +73,7 @@ Deno.serve(async (req) => {
 
 ### Request Object
 
-The function receives a standard Deno `Request` object:
+The function receives a standard `Request` object:
 - `req.json()` - Parse JSON body
 - `req.text()` - Get raw text body
 - `req.headers` - Access request headers
@@ -207,15 +207,32 @@ For more details on deploying, see [functions-deploy.md](functions-deploy.md).
 
 ## Notes
 
-- Functions run on Deno runtime, not Node.js
 - Use `npm:` prefix for npm packages (e.g., `npm:@base44/sdk`)
 - Use `createClientFromRequest(req)` to get a client that inherits the caller's auth context
 - Configure secrets via app dashboard for API keys
 - Make sure to handle errors gracefully and return appropriate HTTP status codes
 
+## Multi-File Functions
+
+A function is not limited to `entry.ts`. Any `.js`, `.ts`, `.json`, or `.jsonc` file in the function's folder is uploaded on deploy and can be imported from `entry.ts` with a relative path.
+
+```
+base44/
+  functions/
+    process-order/
+      entry.ts       ← import { validate } from "./validate.ts";
+      validate.ts    ←   import { Order } from "./types.ts";
+      types.ts
+      config.json
+```
+
+**Rules:**
+- Import files in the same folder with `./`, including the extension (e.g. `./validate.ts`).
+- The entire function folder ships on every deploy; anything the entry does not import is dropped from the bundle, so extra files are harmless.
+
 ## Sharing Code Between Functions
 
-Place shared utilities in `base44/shared/` — the only directory outside a function folder that the CLI will upload.
+To share code across functions, put it in `base44/shared/` — the one directory outside a function folder that the CLI uploads. Its full contents are bundled with **every** function.
 
 ```
 base44/
@@ -229,8 +246,8 @@ base44/
 ```
 
 **Rules:**
-- Shared files **must** live inside `base44/shared/` (or any subdirectory of `base44/`, but `shared/` is the convention).
-- Imports that escape past `base44/` (e.g. `../../../src/utils.ts`) are **blocked at deploy time** with an error — the file can't be uploaded and would fail at runtime anyway.
+- Shared code **must** live in `base44/shared/`. Files elsewhere outside the function folder are not uploaded.
+- A relative import can reach a sibling (`./util.ts`) or `base44/shared/` (`../../shared/util.ts`) — but nothing further out. An import that escapes `base44/` (e.g. `../../../src/utils.ts`) fails at deploy time; move the file into `base44/shared/` instead.
 - For external packages use `npm:` or `jsr:` specifiers, not relative paths.
 
 ## Common Mistakes
@@ -239,6 +256,6 @@ base44/
 |-------|---------|-----|
 | `base44/functions/myFunction.js` (single file) | `base44/functions/my-function/entry.ts` | Functions must live in a named subdirectory |
 | `base44/functions/entry.ts` | `base44/functions/my-function/entry.ts` | The function name comes from the subdirectory path |
-| `import { ... } from "@base44/sdk"` | `import { ... } from "npm:@base44/sdk"` | Deno requires `npm:` prefix for npm packages |
+| `import { ... } from "@base44/sdk"` | `import { ... } from "npm:@base44/sdk"` | npm packages must use the `npm:` prefix |
 | `MyFunction` or `myFunction` directory | `my-function` directory | Use kebab-case for directory names |
 | `import { x } from "../../../src/utils.ts"` | `import { x } from "../../shared/utils.ts"` | Imports outside `base44/` are blocked — move shared code to `base44/shared/` |


### PR DESCRIPTION
## Summary

- Adds a **Sharing Code Between Functions** section to `functions-create.md` explaining that `base44/shared/` is the correct location for shared utilities imported by multiple functions
- Documents that imports escaping past `base44/` are blocked at deploy time (not silently broken at runtime)
- Adds a common-mistakes row for the out-of-bounds import anti-pattern

## Background

Relates to base44/cli#563 (reachability fix) and base44-dev/apper#15510 (server-side path normalization). The CLI now detects and errors on imports outside `base44/` before uploading — this doc update ensures the skill reflects that behavior so future code generation puts shared code in the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)