### PR TITLE
skills(base44-cli): workspace targeting + `workspace list`/`workspace move`

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -244,6 +244,15 @@ npx base44 logs --app-id app_123 --json
 | `base44 eject` | Download the code for an existing Base44 project | [eject.md](references/eject.md) |
 | `base44 dashboard open` | Open the app dashboard in your browser | [dashboard.md](references/dashboard.md) |
 
+### Workspace Management
+
+Apps are created in your **personal workspace** by default. Use `--workspace <id>` on `create`/`link --create` to target another workspace, or move an existing app between workspaces.
+
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `base44 workspace list` | List the workspaces you belong to (and your role in each) | [workspace-list.md](references/workspace-list.md) |
+| `base44 workspace move [workspace-id]` | Move the current app to another workspace | [workspace-move.md](references/workspace-move.md) |
+
 ### Development
 
 | Command | Description | Reference |

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -250,7 +250,7 @@ Apps are created in your **personal workspace** by default. Use `--workspace <id
 
 | Command | Description | Reference |
 |---------|-------------|-----------|
-| `base44 workspace list [--can-create] [--role <role>]` | List the workspaces you belong to (and your role in each); filter with `--can-create` / `--role` | [workspace-list.md](references/workspace-list.md) |
+| `base44 workspace list [--role <role>]` | List the workspaces you belong to (and your role in each); optionally filter with `--role` | [workspace-list.md](references/workspace-list.md) |
 | `base44 workspace get <workspace-id>` | Show a single workspace's details (name, role, tier) by ID | [workspace-get.md](references/workspace-get.md) |
 | `base44 workspace move [workspace-id]` | Move the current app to another workspace | [workspace-move.md](references/workspace-move.md) |
 

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -250,7 +250,8 @@ Apps are created in your **personal workspace** by default. Use `--workspace <id
 
 | Command | Description | Reference |
 |---------|-------------|-----------|
-| `base44 workspace list` | List the workspaces you belong to (and your role in each) | [workspace-list.md](references/workspace-list.md) |
+| `base44 workspace list [--can-create] [--role <role>]` | List the workspaces you belong to (and your role in each); filter with `--can-create` / `--role` | [workspace-list.md](references/workspace-list.md) |
+| `base44 workspace get <workspace-id>` | Show a single workspace's details (name, role, tier) by ID | [workspace-get.md](references/workspace-get.md) |
 | `base44 workspace move [workspace-id]` | Move the current app to another workspace | [workspace-move.md](references/workspace-move.md) |
 
 ### Development

--- a/skills/base44-cli/references/create.md
+++ b/skills/base44-cli/references/create.md
@@ -25,8 +25,19 @@ npx base44 create [name] --path <path> [options]
 | `-t, --template <id>` | Template ID (see templates below) | No |
 | `--deploy` | Build and deploy the site (includes pushing entities) | No |
 | `--no-skills` | Skip AI agent skills installation (skills are added by default) | No |
+| `-w, --workspace <id>` | Workspace (organization) ID to create the app in. Defaults to your personal workspace | No |
 
 *Required for non-interactive mode. Both `name` and `--path` must be provided together.
+
+## Targeting a Workspace
+
+By default, new apps land in your **personal workspace**. To create the app in a specific workspace, pass its ID with `--workspace`:
+
+```bash
+npx base44 create my-app -p ./my-app --workspace 507f1f77bcf86cd799439011
+```
+
+Get workspace IDs with `npx base44 workspace list`. You must be an owner, admin, or editor of the target workspace. To move an app after creation, use [`workspace move`](workspace-move.md).
 
 ## Template Selection (CRITICAL - Choose Appropriately)
 

--- a/skills/base44-cli/references/link.md
+++ b/skills/base44-cli/references/link.md
@@ -23,6 +23,7 @@ npx base44 link [options]
 | `-c, --create` | Create a new project (skip selection prompt) | No |
 | `-n, --name <name>` | Project name (required when `--create` is used) | With `--create` |
 | `-d, --description <description>` | Project description | No |
+| `-w, --workspace <id>` | Workspace (organization) ID to create the app in when using `--create`. Defaults to your personal workspace | No |
 | `--app-id <id>` | App ID to link to an existing project (global flag, skips selection prompt) | No |
 
 ## Non-Interactive Mode
@@ -55,6 +56,9 @@ npx base44 link --create --name my-app
 
 # With description
 npx base44 link --create --name my-app --description "My awesome app"
+
+# Create the new app in a specific workspace
+npx base44 link --create --name my-app --workspace 507f1f77bcf86cd799439011
 
 # Link to a specific existing project by ID
 npx base44 link --app-id abc123

--- a/skills/base44-cli/references/workspace-get.md
+++ b/skills/base44-cli/references/workspace-get.md
@@ -1,0 +1,34 @@
+# base44 workspace get
+
+Shows details for one workspace (organization) by its ID — name, your role, and subscription tier. Useful when you have a workspace ID and want to know what it is without scanning the full `workspace list`.
+
+## Syntax
+
+```bash
+npx base44 workspace get <workspace-id>
+```
+
+## Arguments
+
+| Argument       | Description                  | Required |
+|----------------|------------------------------|----------|
+| `workspace-id` | Workspace (organization) ID  | Yes      |
+
+## Output
+
+Prints the workspace name, ID, your role, and tier. With the global `--json` flag it prints the workspace object:
+
+```bash
+npx base44 workspace get 507f191e810c19729de860ea --json
+```
+
+```json
+{ "id": "507f191e810c19729de860ea", "name": "Acme Inc", "userRole": "admin", "subscriptionTier": "enterprise", "isEnterprise": true, "isPersonal": false }
+```
+
+Fails if you are not a member of a workspace with that ID.
+
+## Related
+
+- [workspace-list.md](workspace-list.md) — list all workspaces you belong to
+- [workspace-move.md](workspace-move.md) — move an app between workspaces

--- a/skills/base44-cli/references/workspace-list.md
+++ b/skills/base44-cli/references/workspace-list.md
@@ -14,12 +14,11 @@ npx base44 workspace list
 
 | Flag             | Description                                                                     |
 |------------------|---------------------------------------------------------------------------------|
-| `--can-create`   | Only workspaces you can create or move apps into (owner, admin, or editor)      |
 | `--role <role>`  | Only workspaces where your role matches (`owner`, `admin`, `editor`, `viewer`)  |
 
 ```bash
-# Only workspaces you can put apps in
-npx base44 workspace list --can-create
+# Only workspaces where you're an admin
+npx base44 workspace list --role admin
 ```
 
 ## Output

--- a/skills/base44-cli/references/workspace-list.md
+++ b/skills/base44-cli/references/workspace-list.md
@@ -1,0 +1,38 @@
+# base44 workspace list
+
+Lists the workspaces (organizations) your account belongs to, with your role in each. Use it to find the workspace ID for `base44 create --workspace` or `base44 workspace move`.
+
+Your personal workspace is listed first.
+
+## Syntax
+
+```bash
+npx base44 workspace list
+```
+
+## Output
+
+Each workspace shows its name, ID, and your role (e.g. `personal, owner` or `admin`).
+
+For scripts, add the global `--json` flag to get a machine-readable array:
+
+```bash
+npx base44 workspace list --json
+```
+
+```json
+[
+  { "id": "507f1f77bcf86cd799439011", "name": "My Workspace", "userRole": "owner", "isPersonal": true },
+  { "id": "507f191e810c19729de860ea", "name": "Acme Inc", "userRole": "admin", "isPersonal": false }
+]
+```
+
+## Notes
+
+- Requires authentication (`npx base44 whoami` should succeed).
+- Only workspaces where your role is `owner`, `admin`, or `editor` can be used as a target for creating or moving apps.
+
+## Related
+
+- [create.md](create.md) — create an app in a workspace with `--workspace`
+- [workspace-move.md](workspace-move.md) — move an app between workspaces

--- a/skills/base44-cli/references/workspace-list.md
+++ b/skills/base44-cli/references/workspace-list.md
@@ -41,7 +41,7 @@ npx base44 workspace list --json
 ## Notes
 
 - Requires authentication (`npx base44 whoami` should succeed).
-- Only workspaces where your role is `owner`, `admin`, or `editor` can be used as a target for creating or moving apps.
+- The server authorizes creating/moving apps into a workspace and returns a clear error if your role doesn't allow it.
 
 ## Related
 

--- a/skills/base44-cli/references/workspace-list.md
+++ b/skills/base44-cli/references/workspace-list.md
@@ -10,6 +10,18 @@ Your personal workspace is listed first.
 npx base44 workspace list
 ```
 
+## Flags
+
+| Flag             | Description                                                                     |
+|------------------|---------------------------------------------------------------------------------|
+| `--can-create`   | Only workspaces you can create or move apps into (owner, admin, or editor)      |
+| `--role <role>`  | Only workspaces where your role matches (`owner`, `admin`, `editor`, `viewer`)  |
+
+```bash
+# Only workspaces you can put apps in
+npx base44 workspace list --can-create
+```
+
 ## Output
 
 Each workspace shows its name, ID, and your role (e.g. `personal, owner` or `admin`).
@@ -34,5 +46,6 @@ npx base44 workspace list --json
 
 ## Related
 
+- [workspace-get.md](workspace-get.md) — show a single workspace by ID
 - [create.md](create.md) — create an app in a workspace with `--workspace`
 - [workspace-move.md](workspace-move.md) — move an app between workspaces

--- a/skills/base44-cli/references/workspace-move.md
+++ b/skills/base44-cli/references/workspace-move.md
@@ -1,0 +1,42 @@
+# base44 workspace move
+
+Moves an app from its current workspace (organization) into another one. The app keeps its ID, data, and owner — only its owning workspace changes.
+
+The app is resolved from the linked project (`base44/.app.jsonc`), the global `--app-id` flag, or the `BASE44_APP_ID` environment variable.
+
+## Syntax
+
+```bash
+npx base44 workspace move [workspace-id] [options]
+```
+
+## Arguments & Options
+
+| Argument/Option | Description | Required |
+|-----------------|-------------|----------|
+| `workspace-id` | Target workspace (organization) ID | Yes (non-interactive) |
+| `--disconnect-integrations` | Disconnect the app's OAuth integrations as part of the move | No |
+| `-y, --yes` | Skip the confirmation prompt | No |
+
+In interactive mode you can omit `workspace-id` to pick the target from a list and confirm. In non-interactive mode (CI, `--json`), the target workspace ID is required.
+
+## Examples
+
+```bash
+# Move the linked app to a workspace
+npx base44 workspace move 507f191e810c19729de860ea
+
+# Move a specific app without prompts (for scripts)
+npx base44 workspace move 507f191e810c19729de860ea --app-id your-app-id --yes
+```
+
+## Requirements
+
+- Must be authenticated (`npx base44 login`).
+- You must be an owner, admin, or editor of the **target** workspace, and your role in the **source** workspace must permit transferring apps out.
+- Purchased (marketplace) apps cannot be moved.
+
+## Related
+
+- [workspace-list.md](workspace-list.md) — find workspace IDs
+- [create.md](create.md) — create an app directly in a workspace


### PR DESCRIPTION
## What

Updates the `base44-cli` skill for the new CLI workspace features (paired with the `base44/cli` change).

## Changes

- New **Workspace Management** section in `SKILL.md` with a commands table and the "apps default to your personal workspace" note.
- `create.md` / `link.md` references: document the `-w, --workspace <id>` flag with examples.
- New reference files `workspace-list.md` and `workspace-move.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171Y6jogaAWB1suBYaEULp1)_