### PR TITLE
Document SSO ID token retrieval

### DIFF
--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -136,10 +136,10 @@ getAccessToken(integrationType) → Promise<string>                           //
 
 ```
 getAccessToken(userId) → Promise<{access_token}>
-getIdToken(userId)     → Promise<string>             // use for identity claims, especially email
+getIdToken(userId)     → Promise<string>             // raw ID token; use for identity claims, especially email
 ```
 
-`getIdToken` returns the current app user's stored OIDC ID token as-is; it does not refresh the token. The service-role client must act on behalf of the same user.
+`getIdToken` returns a raw string, not an `{id_token}` object. Unlike `getAccessToken`'s legacy object-shaped TypeScript signature, its signature matches the runtime response. It returns the current app user's stored OIDC ID token as-is and does not refresh it. The service-role client must act on behalf of the same user.
 
 ---
 
@@ -152,7 +152,7 @@ base44.asServiceRole.entities.Task.list()
 base44.asServiceRole.functions.invoke('name', data)
 base44.asServiceRole.connectors.getConnection('slack')
 base44.asServiceRole.sso.getAccessToken(userId)
-base44.asServiceRole.sso.getIdToken(user.id) // use when you need the email claim
+base44.asServiceRole.sso.getIdToken(userId) // current app user only; use for the email claim
 ```
 
 ---

--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -136,7 +136,10 @@ getAccessToken(integrationType) → Promise<string>                           //
 
 ```
 getAccessToken(userId) → Promise<{access_token}>
+getIdToken(userId)     → Promise<string>             // use for identity claims, especially email
 ```
+
+`getIdToken` returns the current app user's stored OIDC ID token as-is; it does not refresh the token. The service-role client must act on behalf of the same user.
 
 ---
 
@@ -149,6 +152,7 @@ base44.asServiceRole.entities.Task.list()
 base44.asServiceRole.functions.invoke('name', data)
 base44.asServiceRole.connectors.getConnection('slack')
 base44.asServiceRole.sso.getAccessToken(userId)
+base44.asServiceRole.sso.getIdToken(user.id) // use when you need the email claim
 ```
 
 ---

--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -135,11 +135,11 @@ getAccessToken(integrationType) → Promise<string>                           //
 **Backend only, service role required.**
 
 ```
-getAccessToken(userId) → Promise<string>
+getAccessToken(userId) → Promise<{access_token}>
 getIdToken(userId)     → Promise<string>             // raw ID token; use for identity claims, especially email
 ```
 
-Both methods return raw token strings. `getIdToken` returns the current app user's OIDC ID token, and the service-role client must act on behalf of the same user.
+`getIdToken` returns the current app user's OIDC ID token as a raw string, and the service-role client must act on behalf of the same user.
 
 ---
 

--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -135,11 +135,11 @@ getAccessToken(integrationType) → Promise<string>                           //
 **Backend only, service role required.**
 
 ```
-getAccessToken(userId) → Promise<{access_token}>
+getAccessToken(userId) → Promise<string>
 getIdToken(userId)     → Promise<string>             // raw ID token; use for identity claims, especially email
 ```
 
-`getIdToken` returns a raw string, not an `{id_token}` object. Unlike `getAccessToken`'s legacy object-shaped TypeScript signature, its signature matches the runtime response. It returns the current app user's stored OIDC ID token as-is and does not refresh it. The service-role client must act on behalf of the same user.
+Both methods return raw token strings. `getIdToken` returns the current app user's OIDC ID token, and the service-role client must act on behalf of the same user.
 
 ---
 

--- a/skills/base44-sdk/references/sso.md
+++ b/skills/base44-sdk/references/sso.md
@@ -8,12 +8,12 @@ Single Sign-On (SSO) support for authenticating Base44 users with external syste
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `getAccessToken(userId)` | `Promise<SsoAccessTokenResponse>` | Get an SSO access token for a specific user |
+| `getAccessToken(userId)` | `Promise<string>` | Get an SSO access token for a specific user |
 | `getIdToken(userId)` | `Promise<string>` | Get the stored SSO OIDC ID token for the current app user |
 
 Use `getIdToken(userId)` when you need identity claims, especially the user's `email` claim. Use `getAccessToken(userId)` when you need a token to authorize requests to an external system.
 
-The service-role client must include an on-behalf-of token for the same user passed to `getIdToken`. The method returns the stored ID token as-is and does not refresh it.
+Both methods return raw token strings. The service-role client must include an on-behalf-of token for the same user passed to `getIdToken`.
 
 ## Examples
 
@@ -32,10 +32,10 @@ Deno.serve(async (req) => {
   }
 
   // Get SSO access token for this user
-  const { access_token } = await base44.asServiceRole.sso.getAccessToken(user.id);
+  const accessToken = await base44.asServiceRole.sso.getAccessToken(user.id);
 
   // Use the token to authenticate with an external system
-  return Response.json({ ssoToken: access_token });
+  return Response.json({ ssoToken: accessToken });
 });
 ```
 
@@ -47,9 +47,9 @@ Deno.serve(async (req) => {
   const { userId } = await req.json();
 
   // Get SSO token for any user (service role has access to all users)
-  const { access_token } = await base44.asServiceRole.sso.getAccessToken(userId);
+  const accessToken = await base44.asServiceRole.sso.getAccessToken(userId);
 
-  return Response.json({ token: access_token });
+  return Response.json({ token: accessToken });
 });
 ```
 
@@ -84,26 +84,19 @@ Deno.serve(async (req) => {
 ## Type Definitions
 
 ```typescript
-/** Response from the SSO access token endpoint. */
-interface SsoAccessTokenResponse {
-  /** The SSO access token for the specified user. */
-  access_token: string;
-}
-
 /** SSO module for managing SSO authentication (service role only). */
 interface SsoModule {
   /**
    * Gets an SSO access token for a specific user.
    * @param userId - The Base44 user ID to get the SSO token for.
-   * @returns Promise resolving to the SSO access token response.
+   * @returns Promise resolving to the raw SSO access token string.
    */
-  getAccessToken(userId: string): Promise<SsoAccessTokenResponse>;
+  getAccessToken(userId: string): Promise<string>;
 
   /**
    * Gets the stored SSO OIDC ID token for the current app user.
    * Use this method when you need the user's email claim.
    * The service-role client must act on behalf of this same user.
-   * The stored token is returned as-is and is not refreshed.
    * @param userId - The current app user's Base44 user ID.
    * @returns Promise resolving to the raw ID token string.
    */

--- a/skills/base44-sdk/references/sso.md
+++ b/skills/base44-sdk/references/sso.md
@@ -8,12 +8,12 @@ Single Sign-On (SSO) support for authenticating Base44 users with external syste
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `getAccessToken(userId)` | `Promise<string>` | Get an SSO access token for a specific user |
+| `getAccessToken(userId)` | `Promise<SsoAccessTokenResponse>` | Get an SSO access token for a specific user |
 | `getIdToken(userId)` | `Promise<string>` | Get the stored SSO OIDC ID token for the current app user |
 
 Use `getIdToken(userId)` when you need identity claims, especially the user's `email` claim. Use `getAccessToken(userId)` when you need a token to authorize requests to an external system.
 
-Both methods return raw token strings. The service-role client must include an on-behalf-of token for the same user passed to `getIdToken`.
+The service-role client must include an on-behalf-of token for the same user passed to `getIdToken`.
 
 ## Examples
 
@@ -32,10 +32,10 @@ Deno.serve(async (req) => {
   }
 
   // Get SSO access token for this user
-  const accessToken = await base44.asServiceRole.sso.getAccessToken(user.id);
+  const { access_token } = await base44.asServiceRole.sso.getAccessToken(user.id);
 
   // Use the token to authenticate with an external system
-  return Response.json({ ssoToken: accessToken });
+  return Response.json({ ssoToken: access_token });
 });
 ```
 
@@ -47,9 +47,9 @@ Deno.serve(async (req) => {
   const { userId } = await req.json();
 
   // Get SSO token for any user (service role has access to all users)
-  const accessToken = await base44.asServiceRole.sso.getAccessToken(userId);
+  const { access_token } = await base44.asServiceRole.sso.getAccessToken(userId);
 
-  return Response.json({ token: accessToken });
+  return Response.json({ token: access_token });
 });
 ```
 
@@ -84,14 +84,20 @@ Deno.serve(async (req) => {
 ## Type Definitions
 
 ```typescript
+/** Response from the SSO access token endpoint. */
+interface SsoAccessTokenResponse {
+  /** The SSO access token for the specified user. */
+  access_token: string;
+}
+
 /** SSO module for managing SSO authentication (service role only). */
 interface SsoModule {
   /**
    * Gets an SSO access token for a specific user.
    * @param userId - The Base44 user ID to get the SSO token for.
-   * @returns Promise resolving to the raw SSO access token string.
+   * @returns Promise resolving to the SSO access token response.
    */
-  getAccessToken(userId: string): Promise<string>;
+  getAccessToken(userId: string): Promise<SsoAccessTokenResponse>;
 
   /**
    * Gets the stored SSO OIDC ID token for the current app user.

--- a/skills/base44-sdk/references/sso.md
+++ b/skills/base44-sdk/references/sso.md
@@ -9,6 +9,11 @@ Single Sign-On (SSO) support for authenticating Base44 users with external syste
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `getAccessToken(userId)` | `Promise<SsoAccessTokenResponse>` | Get an SSO access token for a specific user |
+| `getIdToken(userId)` | `Promise<string>` | Get the stored SSO OIDC ID token for the current app user |
+
+Use `getIdToken(userId)` when you need identity claims, especially the user's `email` claim. Use `getAccessToken(userId)` when you need a token to authorize requests to an external system.
+
+The service-role client must include an on-behalf-of token for the same user passed to `getIdToken`. The method returns the stored ID token as-is and does not refresh it.
 
 ## Examples
 
@@ -48,6 +53,28 @@ Deno.serve(async (req) => {
 });
 ```
 
+### Get an ID Token for the User's Email Claim
+
+Use an ID token instead of an access token when you need the user's email claim. The ID token is a JWT containing identity claims from the SSO provider. Validate and decode the token according to your provider's requirements before using its claims.
+
+```javascript
+import { createClientFromRequest } from "npm:@base44/sdk";
+
+Deno.serve(async (req) => {
+  const base44 = createClientFromRequest(req);
+
+  const user = await base44.auth.me();
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const idToken = await base44.asServiceRole.sso.getIdToken(user.id);
+
+  // Pass the ID token to code that validates it and reads the email claim.
+  return Response.json({ idToken });
+});
+```
+
 ## Use Cases
 
 - Authenticating Base44 users with external SaaS tools (e.g., Okta, Azure AD)
@@ -67,9 +94,19 @@ interface SsoAccessTokenResponse {
 interface SsoModule {
   /**
    * Gets an SSO access token for a specific user.
-   * @param userid - The Base44 user ID to get the SSO token for.
+   * @param userId - The Base44 user ID to get the SSO token for.
    * @returns Promise resolving to the SSO access token response.
    */
-  getAccessToken(userid: string): Promise<SsoAccessTokenResponse>;
+  getAccessToken(userId: string): Promise<SsoAccessTokenResponse>;
+
+  /**
+   * Gets the stored SSO OIDC ID token for the current app user.
+   * Use this method when you need the user's email claim.
+   * The service-role client must act on behalf of this same user.
+   * The stored token is returned as-is and is not refreshed.
+   * @param userId - The current app user's Base44 user ID.
+   * @returns Promise resolving to the raw ID token string.
+   */
+  getIdToken(userId: string): Promise<string>;
 }
 ```


### PR DESCRIPTION
## Summary

- document `base44.asServiceRole.sso.getIdToken(user.id)` alongside `getAccessToken`
- recommend ID tokens when reading identity claims, especially `email`
- add the return type, request-context constraints, non-refresh behavior, and an example
- update the SDK quick reference

## Why

The SDK exposes an ID-token retrieval method in addition to access-token retrieval, but the SSO references did not describe it. Developers interested in the user's email claim need the OIDC ID token rather than the access token.

## Impact

AI coding agents using these references can select the correct SSO token and call the method with the current user's ID.

## Validation

- `git diff --check`
- `quick_validate.py skills/base44-sdk`
