### PR TITLE
docs: teach the base44:runtime backend-function API, drop Deno syntax

### DIFF
--- a/.claude/skills/sync-cli-skill/SKILL.md
+++ b/.claude/skills/sync-cli-skill/SKILL.md
@@ -316,7 +316,7 @@ After processing all changed commands, update the SKILL.md of each affected skil
 
 ### Step 6b: Flag base44-sandbox for review
 
-The `skills/base44-sandbox/` skill (the cloud-sandbox flavor) is **hand-authored** and self-contained — it carries its own concise guidelines and links out to `base44-cli`'s references rather than copying them, so this sync does not edit it automatically. If this sync changed the backend-function authoring conventions in `skills/base44-cli/references/functions-create.md` (directory layout, `function.jsonc` shape, Deno entry-point conventions, naming rules), **flag `skills/base44-sandbox/SKILL.md` for manual review** in the summary so its inline guidance can be updated to match.
+The `skills/base44-sandbox/` skill (the cloud-sandbox flavor) is **hand-authored** and self-contained — it carries its own concise guidelines and links out to `base44-cli`'s references rather than copying them, so this sync does not edit it automatically. If this sync changed the backend-function authoring conventions in `skills/base44-cli/references/functions-create.md` (directory layout, `function.jsonc` shape, entry-point conventions, naming rules), **flag `skills/base44-sandbox/SKILL.md` for manual review** in the summary so its inline guidance can be updated to match.
 
 ### Step 7: Update CLI_VERSION and Skill Frontmatter
 

--- a/skills/base44-cli/references/functions-create.md
+++ b/skills/base44-cli/references/functions-create.md
@@ -48,27 +48,27 @@ Rules:
 
 ## Entry Point File
 
-Functions export a request handler using `Deno.serve()`. Use the `npm:` prefix to import npm packages.
+Functions export a default request handler. Use the `npm:` prefix to import npm packages.
 
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req: Request): Promise<Response> {
   // Get authenticated client from request
   const base44 = createClientFromRequest(req);
-  
+
   // Parse input
   const { orderId, action } = await req.json();
-  
+
   // Your logic here
   const order = await base44.entities.Orders.get(orderId);
-  
+
   // Return response
   return Response.json({
     success: true,
     order: order
   });
-});
+}
 ```
 
 ### Request Object
@@ -108,11 +108,11 @@ base44/
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req: Request): Promise<Response> {
   try {
     const base44 = createClientFromRequest(req);
     const { orderId } = await req.json();
-    
+
     // Validate input
     if (!orderId) {
       return Response.json(
@@ -120,7 +120,7 @@ Deno.serve(async (req) => {
         { status: 400 }
       );
     }
-    
+
     // Fetch and process the order
     const order = await base44.entities.Orders.get(orderId);
     if (!order) {
@@ -129,20 +129,20 @@ Deno.serve(async (req) => {
         { status: 404 }
       );
     }
-    
+
     return Response.json({
       success: true,
       orderId: order.id,
       processedAt: new Date().toISOString()
     });
-    
+
   } catch (error) {
     return Response.json(
       { error: error.message },
       { status: 500 }
     );
   }
-});
+}
 ```
 
 ## Using Service Role Access
@@ -152,39 +152,54 @@ For admin-level operations, use `asServiceRole`:
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req: Request): Promise<Response> {
   const base44 = createClientFromRequest(req);
-  
+
   // Check user is authenticated
   const user = await base44.auth.me();
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
-  
+
   // Use service role for admin operations
   const allOrders = await base44.asServiceRole.entities.Orders.list();
-  
+
   return Response.json({ orders: allOrders });
-});
+}
 ```
 
 ## Using Secrets
 
-Access environment variables configured in the app dashboard:
+Read secrets configured in the app dashboard with `secrets.get()` from the `base44:runtime` module. `BASE44_APP_ID` is pre-populated; set everything else in app settings → environment variables.
 
 ```typescript
-Deno.serve(async (req) => {
-  // Access environment variables (configured in app settings)
-  const apiKey = Deno.env.get("STRIPE_API_KEY");
-  
+import { secrets } from "base44:runtime";
+
+export default async function (req: Request): Promise<Response> {
+  // Read a secret (configured in app settings)
+  const apiKey = secrets.get("STRIPE_API_KEY");
+
   const response = await fetch("https://api.stripe.com/v1/charges", {
     headers: {
       "Authorization": `Bearer ${apiKey}`
     }
   });
-  
+
   return Response.json(await response.json());
-});
+}
+```
+
+## Post-Response Work
+
+For work that should finish after the response is sent (analytics pings, non-critical logging), pass the promise to `waitUntil()` from `base44:runtime`. The response returns immediately and the function stays alive until the promise settles.
+
+```typescript
+import { waitUntil } from "base44:runtime";
+
+export default async function (req: Request): Promise<Response> {
+  waitUntil(fetch("https://hooks.example.com/ping", { method: "POST" }));
+  return Response.json({ ok: true });
+}
 ```
 
 ## Naming Conventions
@@ -207,9 +222,10 @@ For more details on deploying, see [functions-deploy.md](functions-deploy.md).
 
 ## Notes
 
-- Use `npm:` prefix for npm packages (e.g., `npm:@base44/sdk`)
+- Use `npm:` prefix for npm packages (e.g., `npm:@base44/sdk`), always with a pinned version
 - Use `createClientFromRequest(req)` to get a client that inherits the caller's auth context
-- Configure secrets via app dashboard for API keys
+- Configure secrets via app dashboard for API keys, and read them with `secrets.get()` from `base44:runtime`
+- Crypto is the async Web Crypto API — for Stripe webhooks use `await stripe.webhooks.constructEventAsync(...)`; the synchronous `constructEvent()` throws "SubtleCryptoProvider cannot be used in a synchronous context"
 - Make sure to handle errors gracefully and return appropriate HTTP status codes
 
 ## Multi-File Functions
@@ -248,7 +264,7 @@ base44/
 **Rules:**
 - Shared code **must** live in `base44/shared/`. Files elsewhere outside the function folder are not uploaded.
 - A relative import can reach a sibling (`./util.ts`) or `base44/shared/` (`../../shared/util.ts`) — but nothing further out. An import that escapes `base44/` (e.g. `../../../src/utils.ts`) fails at deploy time; move the file into `base44/shared/` instead.
-- For external packages use `npm:` or `jsr:` specifiers, not relative paths.
+- For external packages use `npm:` specifiers, not relative paths.
 
 ## Common Mistakes
 

--- a/skills/base44-sandbox/SKILL.md
+++ b/skills/base44-sandbox/SKILL.md
@@ -41,21 +41,21 @@ base44/functions/
     entry.ts
 ```
 
-Entry file — functions run on **Deno** (not Node.js), export with `Deno.serve()`, and use the `npm:` prefix for npm packages:
+Entry file — `export default` an async request handler, and use the `npm:` prefix for npm packages:
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);   // inherits the caller's auth
   const { orderId } = await req.json();
   const order = await base44.entities.Orders.get(orderId);
   return Response.json({ success: true, order });
-});
+}
 ```
 Conventions:
 - **Kebab-case** directory and function name; entry typically `entry.ts`.
 - `createClientFromRequest(req)` for a client in the caller's auth context; `base44.asServiceRole.…` for admin-level operations.
-- Read secrets with `Deno.env.get("KEY")` (configured in app settings).
+- Read secrets with `secrets.get("KEY")` from `base44:runtime` (`import { secrets } from "base44:runtime"`; configured in app settings).
 - Return with `Response.json(body, { status })`; handle errors and set appropriate status codes.
 
 That's enough to author functions correctly. For deeper detail and more examples (service role, secrets, common mistakes), see the `base44-cli` skill's reference: [`functions-create.md`](../base44-cli/references/functions-create.md) — but **ignore its "Deploying Functions" / CLI sections** and its **`function.jsonc`** guidance, which assume a local project and do not apply in the sandbox (here you only write `entry.ts`).
@@ -161,7 +161,7 @@ Connecting only authorizes the connector. To actually call the third-party API, 
 ```typescript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
 
   // App-scoped OAuth token — backend / service role only.
@@ -174,7 +174,7 @@ Deno.serve(async (req) => {
   ).then((r) => r.json());
 
   return Response.json({ events });
-});
+}
 ```
 
 Notes: the connector is **app-scoped** (one connected account shared by all users); Base44 refreshes the token for you; you make the API calls. `getConnection()` replaces the deprecated `getAccessToken()`. For the full module reference (signatures, `connectionConfig`, the list of available services and their type identifiers), see the `base44-sdk` skill's [`connectors.md`](../base44-sdk/references/connectors.md).

--- a/skills/base44-sdk/SKILL.md
+++ b/skills/base44-sdk/SKILL.md
@@ -267,16 +267,16 @@ const res = await base44.functions.invoke("processOrder", {
 });
 const result = res.data; // ✅ e.g. res.data.success  (res itself is { data, status, headers, … })
 
-// Backend function (Deno)
+// Backend function
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   const { orderId, action } = await req.json();
   // Process with service role for admin access
   const order = await base44.asServiceRole.entities.Orders.get(orderId);
   return Response.json({ success: true });
-});
+}
 ```
 
 ### Service Role Access
@@ -310,4 +310,4 @@ const token = await base44.asServiceRole.connectors.getAccessToken("slack");
 | `asServiceRole.connectors` (app OAuth) | No | Yes |
 | `asServiceRole.sso` | No | Yes |
 
-Backend functions use `Deno.serve()` and `createClientFromRequest(req)` to get a properly authenticated client.
+Backend functions `export default` an async request handler and use `createClientFromRequest(req)` to get a properly authenticated client.

--- a/skills/base44-sdk/references/QUICK_REFERENCE.md
+++ b/skills/base44-sdk/references/QUICK_REFERENCE.md
@@ -162,7 +162,7 @@ base44.asServiceRole.sso.getIdToken(userId) // current app user only; use for th
 ```javascript
 import { createClientFromRequest } from "@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   const data = await req.json();
   
@@ -173,7 +173,7 @@ Deno.serve(async (req) => {
   const allRecords = await base44.asServiceRole.entities.Task.list();
   
   return Response.json({ success: true });
-});
+}
 ```
 
 ---

--- a/skills/base44-sdk/references/ai-gateway.md
+++ b/skills/base44-sdk/references/ai-gateway.md
@@ -69,7 +69,7 @@ import { ToolLoopAgent, tool, stepCountIs, hasToolCall } from "npm:ai@7.0.16";
 import { createOpenAICompatible } from "npm:@ai-sdk/openai-compatible@3.0.5";
 import { z } from "npm:zod@4.4.3";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   const user = await base44.auth.me();
   if (!user) return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -109,7 +109,7 @@ Deno.serve(async (req) => {
 
   await agent.generate({ prompt: `Review this return request: ${JSON.stringify(request)}` });
   return Response.json({ ok: true });
-});
+}
 ```
 
 **Images:** when the agent needs to see an image, pass it as an image part in `messages`:

--- a/skills/base44-sdk/references/auth.md
+++ b/skills/base44-sdk/references/auth.md
@@ -631,7 +631,7 @@ const user = await base44.auth.me();
 ```javascript
 import { createClientFromRequest } from "@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
 
   // Get user from request context
@@ -639,7 +639,7 @@ Deno.serve(async (req) => {
 
   // User operations here...
   return Response.json({ user });
-});
+}
 ```
 
 ---

--- a/skills/base44-sdk/references/client.md
+++ b/skills/base44-sdk/references/client.md
@@ -57,14 +57,14 @@ const base44 = createClient({
 ```javascript
 import { createClientFromRequest } from "@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   
   // Client inherits authentication from the request
   const user = await base44.auth.me();
   
   return Response.json({ user });
-});
+}
 ```
 
 ## Authentication Modes
@@ -107,7 +107,7 @@ Admin-level access. **Backend only.**
 
 ```javascript
 // Inside a backend function
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   
   // User mode - respects permissions
@@ -119,7 +119,7 @@ Deno.serve(async (req) => {
   const oauthToken = await base44.asServiceRole.connectors.getAccessToken("slack");
   
   return Response.json({ myTasks, allTasks });
-});
+}
 ```
 
 ## Available Modules

--- a/skills/base44-sdk/references/connectors.md
+++ b/skills/base44-sdk/references/connectors.md
@@ -26,7 +26,7 @@ App-scoped OAuth tokens. The app builder connects the account once; all users sh
 
 ```javascript
 // Backend function only
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
 
   // Recommended: use getConnection() for token + optional config
@@ -42,7 +42,7 @@ Deno.serve(async (req) => {
   });
 
   return Response.json(await response.json());
-});
+}
 ```
 
 ```javascript

--- a/skills/base44-sdk/references/functions.md
+++ b/skills/base44-sdk/references/functions.md
@@ -128,7 +128,7 @@ curl -X POST "https://<app-domain>/functions/<function-name>" \
 
 ## Writing Backend Functions
 
-Backend functions run on Deno. Must export using `Deno.serve()`.
+Backend functions are HTTP handlers. Each one must `export default` an async function that takes a `Request` and returns a `Response`.
 
 ### Function Directory Structure
 
@@ -151,22 +151,22 @@ For complete setup and deployment instructions, see [functions-create.md](../../
 // base44/functions/process-order/entry.ts
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   // Get authenticated client from request
   const base44 = createClientFromRequest(req);
-  
+
   // Parse input
   const { orderId, action } = await req.json();
-  
+
   // Your logic here
   const order = await base44.entities.Orders.get(orderId);
-  
+
   // Return response
   return Response.json({
     success: true,
     order: order
   });
-});
+}
 ```
 
 ### With Service Role Access
@@ -174,37 +174,54 @@ Deno.serve(async (req) => {
 ```javascript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
-  
+
   // Check user is authenticated
   const user = await base44.auth.me();
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
-  
+
   // Use service role for admin operations
   const allOrders = await base44.asServiceRole.entities.Orders.list();
-  
+
   return Response.json({ orders: allOrders });
-});
+}
 ```
 
 ### Using Secrets
 
+Read secrets with `secrets.get()` from the `base44:runtime` module. `BASE44_APP_ID` is pre-populated; configure the rest in app settings.
+
 ```javascript
-Deno.serve(async (req) => {
-  // Access environment variables (configured in app settings)
-  const apiKey = Deno.env.get("STRIPE_API_KEY");
-  
+import { secrets } from "base44:runtime";
+
+export default async function (req) {
+  // Read a secret (configured in app settings)
+  const apiKey = secrets.get("STRIPE_API_KEY");
+
   const response = await fetch("https://api.stripe.com/v1/charges", {
     headers: {
       "Authorization": `Bearer ${apiKey}`
     }
   });
-  
+
   return Response.json(await response.json());
-});
+}
+```
+
+### Post-Response Work
+
+To finish work after the response is sent, hand the promise to `waitUntil()` from `base44:runtime`:
+
+```javascript
+import { waitUntil } from "base44:runtime";
+
+export default async function (req) {
+  waitUntil(fetch("https://hooks.example.com/ping", { method: "POST" }));
+  return Response.json({ ok: true });
+}
 ```
 
 ### Error Handling
@@ -212,11 +229,11 @@ Deno.serve(async (req) => {
 ```javascript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   try {
     const base44 = createClientFromRequest(req);
     const { orderId } = await req.json();
-    
+
     const order = await base44.entities.Orders.get(orderId);
     if (!order) {
       return Response.json(
@@ -224,16 +241,16 @@ Deno.serve(async (req) => {
         { status: 404 }
       );
     }
-    
+
     return Response.json({ order });
-    
+
   } catch (error) {
     return Response.json(
       { error: error.message },
       { status: 500 }
     );
   }
-});
+}
 ```
 
 ## Setup Requirements

--- a/skills/base44-sdk/references/sso.md
+++ b/skills/base44-sdk/references/sso.md
@@ -22,7 +22,7 @@ The service-role client must include an on-behalf-of token for the same user pas
 ```javascript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
 
   // Get the current user
@@ -36,13 +36,13 @@ Deno.serve(async (req) => {
 
   // Use the token to authenticate with an external system
   return Response.json({ ssoToken: access_token });
-});
+}
 ```
 
 ### Get Token for a Specific User (Service Role)
 
 ```javascript
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
   const { userId } = await req.json();
 
@@ -50,7 +50,7 @@ Deno.serve(async (req) => {
   const { access_token } = await base44.asServiceRole.sso.getAccessToken(userId);
 
   return Response.json({ token: access_token });
-});
+}
 ```
 
 ### Get an ID Token for the User's Email Claim
@@ -60,7 +60,7 @@ Use an ID token instead of an access token when you need the user's email claim.
 ```javascript
 import { createClientFromRequest } from "npm:@base44/sdk";
 
-Deno.serve(async (req) => {
+export default async function (req) {
   const base44 = createClientFromRequest(req);
 
   const user = await base44.auth.me();
@@ -72,7 +72,7 @@ Deno.serve(async (req) => {
 
   // Pass the ID token to code that validates it and reads the email claim.
   return Response.json({ idToken });
-});
+}
 ```
 
 ## Use Cases


### PR DESCRIPTION
## Summary

Ports [base44-dev/apper#16956](https://github.com/base44-dev/apper/pull/16956) to the skills docs. That PR taught the builder prompts the `base44:runtime` API for Cloudflare apps; the skills here still taught the Deno shape, so anything generated from these docs disagreed with what the builder now emits.

Every `Deno.*` mention is gone from the repo.

| Old | New |
|---|---|
| `Deno.serve(async (req) => {…})` | `export default async function (req) {…}` |
| `Deno.env.get("NAME")` | `import { secrets } from "base44:runtime"` → `secrets.get("NAME")` |
| — | `waitUntil()` from `base44:runtime` for post-response work |
| `npm:` or `jsr:` | `npm:` only, pinned versions |
| "Deno crypto is async" | "Web Crypto API is async" |
| "functions run on Deno" | "HTTP handlers" |

Beyond the mechanical swap, the one addition is a **Post-Response Work** section in both `base44-cli/references/functions-create.md` and `base44-sdk/references/functions.md` covering `waitUntil`.

The upstream PR also added guidance that top-level init is a boot error rather than a 500 (so secret-consuming clients must be constructed inside the handler). That is deliberately **not** in this PR — it can land separately.

## Files

- `skills/base44-cli/references/functions-create.md`
- `skills/base44-sdk/SKILL.md` + `references/{functions,sso,client,auth,connectors,ai-gateway,QUICK_REFERENCE}.md`
- `skills/base44-sandbox/SKILL.md`
- `.claude/skills/sync-cli-skill/SKILL.md` (wording only)

## Two things for the reviewer

1. **`functions-create.md` is sync-managed.** `.claude/skills/sync-cli-skill` regenerates it from the CLI. If the CLI's own docs still say `Deno.serve`, the next sync reverts this file — the upstream CLI docs probably need the same change.
2. **This is unconditional.** apper#16956 gated everything on `is_cloudflare_backend` so Deno V1 apps keep the old syntax. The skills docs have no equivalent flag, so this assumes the CLI and sandbox target CFW exclusively. If Deno V1 apps still ship through these paths, the docs need a branch or a note.

## Verification

`grep -rni "deno\|jsr:" skills/ .claude/ plugins/` returns nothing. Docs-only change — no code or tests in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)