### PR TITLE
docs(base44-cli): route dev and build through the CLI

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -20,6 +20,8 @@ This skill activates on ANY mention of "base44" or when a `base44/` folder exist
 2. If **YES** (existing project scenario):
    - Transfer to base44-sdk skill for implementation
    - This skill only handles CLI commands (login, deploy, entities push)
+   - **Except running the app locally** — stays here. Read [Running Local Development](#running-local-development)
+     before starting a dev server: one way of running hits production data.
 3. If **NO**, decide between two initialization paths:
    - **Provisioned app** — the Base44 app already exists because it was just provisioned through a Stripe Projects / projects.dev flow, OR `BASE44_APP_ID` (or `BASE44_PROJECTS_BASE44_APP_ID`) is present in the environment or a `.env`/`.env.local` file:
      - Run `npx base44 scaffold` to set up local files for that **existing** app
@@ -559,12 +561,23 @@ npx base44 link --create --name my-app
 ```
 
 ### Running Local Development
-```bash
-# Starts the Base44 backend locally
-npx base44 dev
-```
 
-If you want `base44 dev` to run your frontend too, verify `base44/config.jsonc` has `site.serveCommand` set correctly (for example, `"serveCommand": "npm run dev"`). When that field is present, `base44 dev` runs both the backend and the frontend together.
+`npx base44 dev` starts the Base44 backend locally (entities, functions, auth) on a throwaway
+in-memory database — empty each start, gone on stop. A backend-only project needs nothing else; it
+also runs your frontend when `base44/config.jsonc` sets `site.serveCommand`, wired to that local
+backend.
+
+Running the frontend by itself talks to a different backend:
+
+| Command | Backend + data |
+|---------|----------------|
+| `npx base44 dev` | **local** — the throwaway one above |
+| `npm run dev` | **production** — the real app's live data |
+
+**Default to `npx base44 dev`.** Use `npm run dev` only when the user wants real data: every write
+hits the live app. The browser can't tell the modes apart; the vite startup line can —
+`[base44] Proxy enabled: /api -> https://base44.app (default)` means production. Say which you
+started. Options: [dev.md](references/dev.md).
 
 ### Deploying All Changes
 ```bash

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -562,21 +562,23 @@ npx base44 link --create --name my-app
 
 ### Running Local Development
 
-`npx base44 dev` starts the Base44 backend locally (entities, functions, auth) on a throwaway
-in-memory database — empty each start, gone on stop. A backend-only project needs nothing else; it
-also runs your frontend when `base44/config.jsonc` sets `site.serveCommand`, wired to that local
-backend.
-
-Running the frontend by itself talks to a different backend:
+Always run through the CLI — two modes:
 
 | Command | Backend + data |
 |---------|----------------|
-| `npx base44 dev` | **local** — the throwaway one above |
-| `npm run dev` | **production** — the real app's live data |
+| `npx base44 dev` | **local** — throwaway, empty each start, gone on stop |
+| `npx base44 dev --remote` | **production** — the real app's live data |
 
-**Default to `npx base44 dev`.** Use `npm run dev` only when the user wants real data: every write
-hits the live app. The browser can't tell the modes apart; the vite startup line can —
-`[base44] Proxy enabled: /api -> https://base44.app (default)` means production. Say which you
+`base44 dev` starts the local backend (entities, functions, auth) and also serves your frontend when
+`base44/config.jsonc` sets `site.serveCommand`; a backend-only project needs nothing else.
+`--remote` runs *only* the frontend against the real backend, so it needs both a linked project and
+`site.serveCommand`.
+
+Don't run `npm run dev` yourself: without the env vars the CLI injects, the app has no backend to
+reach — the dev server prints which command to use instead.
+
+**Default to `npx base44 dev`.** Under `--remote` every write hits the live app. The vite startup
+line names the backend either way: `[base44] Proxy enabled: /api -> <target>`. Say which you
 started. Options: [dev.md](references/dev.md).
 
 ### Deploying All Changes

--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -271,12 +271,14 @@ Workspaces (a.k.a. organizations) group apps under shared membership. By default
 | Command | Description | Reference |
 |---------|-------------|-----------|
 | `base44 dev` | Start local development for your Base44 backend, and your frontend too when `site.serveCommand` is configured | [dev.md](references/dev.md) |
+| `base44 dev --remote` | Serve the frontend locally against the **production** backend | [dev.md](references/dev.md) |
 
 ### Deployment
 
 | Command | Description | Reference |
 |---------|-------------|-----------|
-| `base44 deploy` | Deploy all resources (entities, functions, agents, agent skills, connectors, auth config, and site) | [deploy.md](references/deploy.md) |
+| `base44 build` | Build the site with its app id injected — use instead of a bare `npm run build` | — |
+| `base44 deploy` | Deploy all resources (entities, functions, agents, agent skills, connectors, auth config, and site); asks whether to build first, or pass `--build` / `--no-build` | [deploy.md](references/deploy.md) |
 
 ### Entity Management
 
@@ -525,8 +527,7 @@ Run one-off scripts against your app with the Base44 SDK pre-authenticated. Use 
 
 5. Build and deploy everything:
    ```bash
-   npm run build
-   npx base44 deploy -y
+   npx base44 deploy --build -y
    ```
 
 Or deploy individual resources:
@@ -586,12 +587,14 @@ started. Options: [dev.md](references/dev.md).
 # Generate types (optional, for TypeScript projects)
 npx base44 types generate
 
-# Build your project first
-npm run build
-
-# Deploy everything (entities, functions, and site)
-npx base44 deploy -y
+# Deploy everything (entities, functions, and site), building the site first
+npx base44 deploy --build -y
 ```
+
+Build through the CLI, not with `npm run build`: `npx base44 build` injects `VITE_BASE44_APP_ID`,
+which a bare `npm run build` leaves unset — the bundle then can't resolve its own app and every API
+call on the deployed site fails. `npx base44 deploy` asks whether to build first; `--build` /
+`--no-build` answers up front (non-interactive defaults to upload-only, so CI is unchanged).
 
 ### Generating TypeScript Types
 ```bash
@@ -657,5 +660,6 @@ Most commands require authentication. If you're not logged in, the CLI will auto
 | Duplicate connector type    | Each connector type can only be defined once per project                            |
 | Connector authorization timeout | Re-run `npx base44 connectors push` and complete the OAuth flow in your browser  |
 | No site configuration found | Check that `site.outputDirectory` is configured in project config                   |
-| Site deployment fails       | Ensure you ran `npm run build` first and the build succeeded                        |
+| Site deployment fails       | Ensure the site was built first (`npx base44 build`, or `npx base44 deploy --build`) and the build succeeded |
+| Deployed site's API calls all fail | The bundle was built without its app id — rebuild with `npx base44 build`, not a bare `npm run build`, and redeploy |
 | Update available message    | If prompted to update, run `npm install -g base44@latest` (or use npx for local installs) |

--- a/skills/base44-cli/references/dev.md
+++ b/skills/base44-cli/references/dev.md
@@ -15,6 +15,7 @@ npx base44 dev [options]
 | Option | Description | Required | Default |
 |--------|-------------|----------|---------|
 | `-p, --port <number>` | Port for the local Base44 backend | No | 4400 |
+| `--remote` | Serve only the frontend, against your app's production backend | No | — |
 
 ## Authentication
 
@@ -54,6 +55,12 @@ Before using `base44 dev` for full-stack local development, verify your config:
 
 If `site.serveCommand` is missing, `base44 dev` still works, but it only starts the Base44 backend.
 
+## Remote Mode (`--remote`)
+
+`npx base44 dev --remote` starts no local backend: it runs only your frontend (`site.serveCommand`),
+wired to your app's **production** backend — every read and write hits live data. Use it to develop
+the UI against real content; default to plain `base44 dev` otherwise.
+
 ## Examples
 
 ```bash
@@ -62,6 +69,9 @@ npx base44 dev
 
 # Start the backend on a specific port
 npx base44 dev --port 4500
+
+# Frontend only, against the production backend (live data)
+npx base44 dev --remote
 ```
 
 ## Notes


### PR DESCRIPTION
## ✅ MERGED 2026-08-30 — gate cleared

Both gates listed below landed weeks ago: `base44/cli`#580 merged 2026-08-06 and shipped in cli v0.1.9
(2026-08-11, now v0.1.12); `base44-dev/vite-plugin`#102 merged 2026-08-05 and shipped in
`@base44/vite-plugin` 1.0.31+. Before merging, every claim in this diff was re-verified against cli
`origin/main` (v0.1.12) — `--remote` semantics, the `--port` rejection, `VITE_BASE44_APP_ID` injection
in `site-build.ts`, and the `deploy` build-ask with its non-interactive upload-only default all still
match the code.

Part of the re-scoped local-dev plan (login is out of scope; the five earlier PRs are closed).

| Repo | PR | Relationship |
|------|----|--------------|
| `base44/cli` | [#580](https://github.com/base44/cli/pull/580) | ships all four surfaces this documents (`dev`, `dev --remote`, `build`, `deploy --build`). #581 was folded into it. **This doc must not merge before it** — it names commands that PR introduces |
| `base44-dev/vite-plugin` | [#102](https://github.com/base44-dev/vite-plugin/pull/102) | the console messages that make "don't run `npm run dev` / `npm run build` yourself" actionable. **No dependency either way** — neither PR quotes the other's strings |

Semantics here are verified against landed code and an independent QA pass on a clean scratch app
(`base44 build` bakes the id; the previously-broken deployed bundle now returns 200 where it 404'd),
not against a spec.

### Why this should merge early in the train, not last

This PR does two different jobs, and the second one changes its urgency:

1. **Additive** — documents `base44 dev --remote` and `base44 build`. Safe to land any time after cli#580.
2. **Corrective** — the skill currently instructs the *broken* build path in four places. Every hour
   it stays unmerged, the published skill tells agents to run a bare `npm run build`, producing a
   bundle with no app id whose every API call fails once deployed.

Job 2 has no plugin dependency, so the cheapest safe order is **cli#580 → cli release → this →
plugin#102 → plugin release** (endorsed by the vite-plugin lane, which owned the earlier ordering).

## The problem

An app can be run locally two ways and the skills documented one. `SKILL.md` offered only
`npx base44 dev`; nothing said a production-backed mode exists, or which mode touches live data.

Second-order problem: `SKILL.md`'s routing block sent every existing-project case
(`base44/config.jsonc` exists) to `base44-sdk` with "this skill only handles CLI commands" — precisely
the user who wants to run their app, routed away from the guidance.

## The change

One file, `skills/base44-cli/SKILL.md`.

**Routing (§ IMMEDIATE ACTION REQUIRED).** Existing-project cases still hand off to `base44-sdk`, with
one carve-out: running the app locally stays here, and the agent reads the mode guidance *before*
starting a dev server.

**§ Running Local Development.** A two-row table with the data consequence in it, a stated default, the
`site.serveCommand` / linked-project preconditions, and one line telling agents not to run `npm run dev`
directly (the plugin's message covers them if they do). Backend-only projects stay first-class — the
`backend-only` template ships no frontend at all.

**Kept short deliberately.** This is `SKILL.md`; it loads into every agent's context. Net ~+15 lines. It
orients on the decision and delegates detail to `dev.md`.

## History

Earlier revisions of this PR documented the option-A `redirectToLogin` fix in `skills/base44-sdk`, then
a `base44 dev` vs bare `npm run dev` mode table. Both described plans that were dropped; `base44-sdk` is
untouched and the `npm run dev` → production row is gone, since the plugin fallback that made it true
never ships.

Reviewed on the `investigate-login` channel by the cli, plugin, sdk, apper and test-runner lanes. Two
corrections from that review survive into this version: the detection heuristic (the vite startup line
names the backend) and binding the frontend to `site.serveCommand` rather than to a frontend merely
existing.

Deliberately omitted to protect context: unlinked-project failure modes, `base44 dev` passing
unimplemented API routes to production, the local DB also clearing on schema change, and media uploads
living in a temp dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

