### PR TITLE
docs(base44-cli): document the workflows list/runs commands

### DIFF
--- a/skills/base44-cli/SKILL.md
+++ b/skills/base44-cli/SKILL.md
@@ -322,6 +322,15 @@ For complete documentation, see [entities-create.md](references/entities-create.
 | `base44 functions list`   | List all deployed functions on Base44 remote  | [functions-list.md](references/functions-list.md)       |
 | `base44 functions pull [name]` | Pull deployed functions from Base44 to local files | [functions-pull.md](references/functions-pull.md)  |
 
+### Workflow Runs
+
+Workflows are the automation system (cron schedules, entity triggers, connector events, in-app agent actions). These commands are read-only: they answer "what workflows exist" and "did my scheduled work fail, and why".
+
+| Command | Description | Reference |
+|---------|-------------|-----------|
+| `base44 workflows list` | List this app's workflows with status and run summary | [workflows-list.md](references/workflows-list.md) |
+| `base44 workflows runs [--status <s>] [--since <t>]` | List workflow runs, newest first; failed runs include the underlying error | [workflows-runs.md](references/workflows-runs.md) |
+
 ### Agent Management
 
 Agents are conversational AI assistants that can interact with users, access your app's entities, and call backend functions. Use these commands to manage agent configurations.

--- a/skills/base44-cli/references/workflows-list.md
+++ b/skills/base44-cli/references/workflows-list.md
@@ -1,0 +1,35 @@
+# base44 workflows list
+
+List this app's workflows with their status and run summary.
+
+## Syntax
+
+```bash
+npx base44 workflows list [options]
+```
+
+This command can run from a linked project, or outside a project when you pass `--app-id <id>` or set `BASE44_APP_ID`.
+
+## Examples
+
+```bash
+# Show all workflows and how their last run went
+npx base44 workflows list
+
+# Machine-readable output
+npx base44 workflows list --json
+```
+
+## Output
+
+```
+nightly-sync  [active]  runs: 12, last run failed at 2026-08-05T03:00:00Z (3 consecutive failures)
+weekly-digest  [paused]  runs: 4, last run success at 2026-08-01T09:00:00Z
+```
+
+With `--json`, each workflow is a record: `id`, `name`, `description`, `status`, `statusReason`, `totalRuns`, `consecutiveFailures`, `lastRunAt`, `lastRunStatus`.
+
+## Notes
+
+- `consecutiveFailures > 0` is the signal a workflow needs attention — follow up with `base44 workflows runs --status failed`.
+- **Apps that predate Workflows** (legacy automations) are not readable via this command; it fails with an explanation.

--- a/skills/base44-cli/references/workflows-list.md
+++ b/skills/base44-cli/references/workflows-list.md
@@ -10,6 +10,12 @@ npx base44 workflows list [options]
 
 This command can run from a linked project, or outside a project when you pass `--app-id <id>` or set `BASE44_APP_ID`.
 
+## Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `-n, --limit <n>` | Number of workflows to return (1-200, default: 30) | No |
+
 ## Examples
 
 ```bash
@@ -18,6 +24,9 @@ npx base44 workflows list
 
 # Machine-readable output
 npx base44 workflows list --json
+
+# Show more than the default 30
+npx base44 workflows list -n 100
 ```
 
 ## Output
@@ -33,3 +42,4 @@ With `--json`, each workflow is a record: `id`, `name`, `description`, `status`,
 
 - `consecutiveFailures > 0` is the signal a workflow needs attention — follow up with `base44 workflows runs --status failed`.
 - **Apps that predate Workflows** (legacy automations) are not readable via this command; it fails with an explanation.
+- `--limit` tops out at **200** and there is no paging flag, so an app with more than 200 workflows cannot be listed exhaustively from the CLI. Do not read a full page as "that's all of them".

--- a/skills/base44-cli/references/workflows-runs.md
+++ b/skills/base44-cli/references/workflows-runs.md
@@ -47,7 +47,7 @@ With `--json`, each run is a record: `runId`, `workflowId`, `workflowName`, `tri
 
 ## Notes
 
-- **Trigger types**: `scheduled` (cron), `entity`, `connector`, `in_app_agent`, and `manual`.
+- **Trigger types**: `scheduled` (cron), `entity`, `connector`, `in_app_agent`, `app_user_auth`, `app_publish`, `app_payment`, `webhook`, `goal_file` — plus `manual`, which is what a run is stamped with when it was dispatched without a trigger type at all (a "run now" typically lands here).
 - **Test runs are included.** Runs fired via "run now" (including the dashboard's test button) carry a `test` tag appended to the trigger type in the output (e.g. `(scheduled, test)`) and `isTestRun: true` in JSON. If you just created a workflow and fired it to verify, your run WILL appear — marked as a test run.
 - A failed run's `errorMessage` names the failing task and, when a backend function was the cause, includes the function's HTTP failure. To dig further into that function's own logs, use `base44 logs --function <name>` — and remember function logs can take ~30s to appear.
 - `--limit` tops out at **200** and there is no paging flag, so a busy app's older runs cannot be reached from the CLI. Narrow with `--since` and `--status` rather than assuming a full page is the whole history.

--- a/skills/base44-cli/references/workflows-runs.md
+++ b/skills/base44-cli/references/workflows-runs.md
@@ -48,8 +48,9 @@ With `--json`, each run is a record: `runId`, `workflowId`, `workflowName`, `tri
 ## Notes
 
 - **Trigger types**: `scheduled` (cron), `entity`, `connector`, `in_app_agent`, and `manual`.
-- **Test runs are included.** Runs fired via "run now" (including the dashboard's test button) are marked `(test)` in the output and `isTestRun: true` in JSON. If you just created a workflow and fired it to verify, your run WILL appear — marked as a test run.
+- **Test runs are included.** Runs fired via "run now" (including the dashboard's test button) carry a `test` tag appended to the trigger type in the output (e.g. `(scheduled, test)`) and `isTestRun: true` in JSON. If you just created a workflow and fired it to verify, your run WILL appear — marked as a test run.
 - A failed run's `errorMessage` names the failing task and, when a backend function was the cause, includes the function's HTTP failure. To dig further into that function's own logs, use `base44 logs --function <name>` — and remember function logs can take ~30s to appear.
+- `--limit` tops out at **200** and there is no paging flag, so a busy app's older runs cannot be reached from the CLI. Narrow with `--since` and `--status` rather than assuming a full page is the whole history.
 - `statusReason` is a typed reason populated only for failed/cancelled runs (e.g. `insufficient_credits`); read it together with `status`.
 - **Apps that predate Workflows** (legacy automations) are not readable via this command; it fails with an explanation rather than returning an empty list.
 - An empty result tells you whether the app has no workflows at all, or has workflows but no matching runs — read the message, don't assume.

--- a/skills/base44-cli/references/workflows-runs.md
+++ b/skills/base44-cli/references/workflows-runs.md
@@ -1,0 +1,55 @@
+# base44 workflows runs
+
+List workflow runs for this app, newest first. This is the fastest way to answer "did my scheduled work fail, and why" — each failed run carries the task that failed and the underlying error.
+
+## Syntax
+
+```bash
+npx base44 workflows runs [options]
+```
+
+This command can run from a linked project, or outside a project when you pass `--app-id <id>` or set `BASE44_APP_ID`.
+
+## Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--status <status>` | Filter by run status: `running`, `completed`, `failed`, `cancelled` | No |
+| `--since <datetime>` | Show runs started after this time. ISO datetime or relative shorthand (e.g. `1h`, `30m`, `2d`) | No |
+| `-n, --limit <n>` | Number of runs to return (1-200, default: 30) | No |
+
+## Examples
+
+```bash
+# Latest runs across all workflows
+npx base44 workflows runs
+
+# Did anything fail? (start here when debugging)
+npx base44 workflows runs --status failed
+
+# Failures in the last day
+npx base44 workflows runs --status failed --since 1d
+
+# Machine-readable output
+npx base44 workflows runs --status failed --json
+```
+
+## Output
+
+Each run shows its start time, status, workflow name, trigger type, and duration. Failed and cancelled runs also show the error:
+
+```
+2026-08-05 04:00:46 FAILED    nightly-sync  (scheduled)  56.8s
+    Task 'call_fn' failed: Backend function 'sync-orders' returned HTTP 500: {...}
+```
+
+With `--json`, each run is a record: `runId`, `workflowId`, `workflowName`, `triggerType`, `status`, `startedAt`, `completedAt`, `durationMs`, `stepsCount`, `errorMessage`, `isTestRun`, `statusReason`.
+
+## Notes
+
+- **Trigger types**: `scheduled` (cron), `entity`, `connector`, `in_app_agent`, and `manual`.
+- **Test runs are included.** Runs fired via "run now" (including the dashboard's test button) are marked `(test)` in the output and `isTestRun: true` in JSON. If you just created a workflow and fired it to verify, your run WILL appear — marked as a test run.
+- A failed run's `errorMessage` names the failing task and, when a backend function was the cause, includes the function's HTTP failure. To dig further into that function's own logs, use `base44 logs --function <name>` — and remember function logs can take ~30s to appear.
+- `statusReason` is a typed reason populated only for failed/cancelled runs (e.g. `insufficient_credits`); read it together with `status`.
+- **Apps that predate Workflows** (legacy automations) are not readable via this command; it fails with an explanation rather than returning an empty list.
+- An empty result tells you whether the app has no workflows at all, or has workflows but no matching runs — read the message, don't assume.


### PR DESCRIPTION
Reference pages + SKILL.md command-table section for the new read-only `base44 workflows` command group.

**Pairs with [base44/cli#591](https://github.com/base44/cli/pull/591) — merge after the CLI release that ships it**, since these pages name commands that don't exist in the published CLI yet.

- `references/workflows-list.md` — workflows with status + run summary; `consecutiveFailures` as the attention signal
- `references/workflows-runs.md` — the failed-first debugging flow (`--status failed`), `--since`/`-n` filters, `--json` record shape
- Both teach the sharp edges: run-now runs are test runs and still shown (marked), legacy pre-Workflows apps get a refusal not an empty list, and empty results distinguish "no workflows" from "no matching runs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)