### PR TITLE
docs(base44-troubleshooter): name both causes of the polling fallback

### DIFF
--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -162,7 +162,8 @@ The CLI handles all of this for you — this section matters only if you are con
   `false` is your choice as a raw consumer — the bounded polling route is the obvious
   one — but note the CLI itself does **not** do that: it ends the run with an error
   (see above). (And a fallback to polling in the CLI is driven by the *first*
-  connection being refused, never by an end frame.)
+  connection failing — either refused outright, or still unreachable after its
+  retries — never by an end frame.)
 - Reconnect on a drop rather than giving up on the first one. Carry the last seen
   timestamp across the reconnect — but for **dedupe**, and to resume a polling
   fallback where the stream left off. It does not make the handover gapless: a tail


### PR DESCRIPTION
One-line follow-up to #157, from `cli-logs-realtime`'s post-merge review.

The aside in **Driving the SSE endpoint directly** said the CLI's polling fallback is *"driven by the first connection being refused"*. That is one of two causes — a first connect that keeps failing transiently also exhausts its retries and polls (`connectWhileTransientlyUnavailable` → `opened.kind !== "stream"` → warn + `pollLogs`).

The **Streaming or polling is decided once, at startup** section on the same page already documents both cases correctly, so the aside contradicted its own page. No reader was likely to be misled, but it was wrong in `main`.

Verified against cli `main` at `50ad740`, `packages/cli/src/cli/commands/project/logs.ts:256-266`.