### PR TITLE
docs(base44-troubleshooter): say that `--follow --json` is NDJSON

### DIFF
--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -79,7 +79,8 @@ npx base44 logs --follow --function my-function
 - `--env` defaults to `preview`. If `prod` returns no logs, the app may not have been published yet — try `--env preview` to see draft logs.
 - **`No logs found matching the filters.` is ambiguous.** It means one of: the run has not been ingested yet (~20-30s; wait and re-run — *do not* change flags), there is no function by that name, or a `--function` filter dropped unstamped rows from a legacy per-function deployment. It never means "the app is healthy".
 - `--follow` streams logs indefinitely (oldest to newest) instead of a single fetch; it's incompatible with `--since`, `--until` and `--order`. A stream that is lost and cannot be re-established ends the command with an error rather than dropping to polling. See [Following logs live](#following-logs-live).
-- Pass the global `--json` flag to emit each log entry (or, with `--follow`, each new line) as JSON instead of the human-readable format.
+- Pass the global `--json` flag to emit each log entry as JSON instead of the human-readable format.
+- **With `--follow`, `--json` output is one JSON object per line, not one JSON document.** Parse it line by line as it arrives; there is no closing bracket, because a live tail never ends normally. If the stream is lost, the error arrives as one more object on its own line — `{"error": "The realtime log stream stopped and could not be re-established", "code": "API_ERROR", "hints": [...]}` — so a consumer that parses per line sees the failure as data rather than as a broken document.
 
 ## Following logs live
 


### PR DESCRIPTION
Follow-up to #157 / #158, from `cli-logs-realtime`'s reading of the CLI source.

`base44 logs --follow --json` does **not** produce the "single machine-readable JSON document" the CLI's `--json` convention promises elsewhere — a live tail can't. Verified in cli `main`:

- `writeFollowLine` (`packages/cli/src/cli/commands/project/logs.ts:127-130`) writes one `JSON.stringify(entry)` per line as lines arrive.
- On a lost stream, `writeJsonError` (`packages/cli/src/cli/utils/command/Base44Command.ts:42-66`) appends **one more object** on its own line, carrying `error`, `code: "API_ERROR"` and the two hints, because `streamLostError()` is an `ApiError`.

So a consumer waiting for a closing bracket waits forever, and one that parses per line sees the failure as data. This page is read mainly by agents driving the CLI from a loop, which is exactly who that bites.

Adds the NDJSON rule and shows the error envelope.

**Note:** this commit was originally pushed to #158's branch a moment after that PR merged, so it never appeared in it. Re-homed here off current `main` — no content change.