### PR TITLE
docs(base44-troubleshooter): show the lines as they are actually printed

### DIFF
--- a/skills/base44-troubleshooter/SKILL.md
+++ b/skills/base44-troubleshooter/SKILL.md
@@ -41,8 +41,8 @@ function is the expected result, not evidence of a problem.
 
 - **Live debugging: use `--follow`.** Where the realtime stream is available it
   delivers lines in **under a second**. Where it is not, the CLI says so and polls
-  instead (`Realtime logs are not available for this app — falling back to polling
-  (lines may lag ~20-30s).`). Either way `--follow` is the right tool — you never
+  instead (`Warning: Realtime logs are not available for this app — falling back to
+  polling (lines may lag ~20-30s).`). Either way `--follow` is the right tool — you never
   have to pick.
 - **One-shot fetches lag ~20-30s.** That is ingestion time, not a filter problem.
 - **When output is empty, the variable to change is TIME, never a flag.** Wait and
@@ -78,10 +78,10 @@ a healthy stream:
 - **The mode is decided once, at startup.** If the first connection is refused or
   unreachable, the run polls for its whole life. If the stream opens, there is no
   polling fallback left.
-- **A stream lost mid-run ends the command** with
-  `The realtime log stream stopped and could not be re-established`. That non-zero
-  exit is the stream giving up, not proof that logging is broken — re-run the same
-  command rather than changing flags.
+- **A stream lost mid-run ends the command** with `Error: The realtime log stream
+  stopped and could not be re-established`, exit code 1. That exit is the stream
+  giving up, not proof that logging is broken — re-run the same command rather than
+  changing flags.
 
 ### 2. Ask whether it was a scheduled run, not a request
 

--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -120,6 +120,13 @@ Either way the command keeps working; the only difference is latency. On a legac
 per-function app, `--follow --function <name>` is refused (404) and polls — that
 self-heals on the app's next deploy, there is nothing to fix.
 
+Both warnings go to **stderr**, never into the log output on stdout. They are shown
+above as they appear when output is **piped or otherwise not a terminal** — which is
+how an agent or a script sees them. In an interactive terminal the same text is
+rendered by the fancy logger with a coloured glyph instead of the literal
+`Warning: ` prefix, so match on the sentence, not on the prefix. Under `--json`
+there is no warning line at all.
+
 ### A stream that dies mid-run ends the command — it does not quietly start polling
 
 Once the stream has opened there is **no polling fallback left**. If it is lost and
@@ -131,7 +138,11 @@ Error: The realtime log stream stopped and could not be re-established
 ```
 
 It exits **1**, and suggests starting a new tail (`base44 logs --follow`) or reading
-recent logs without streaming (`base44 logs`).
+recent logs without streaming (`base44 logs`). As with the warnings, the literal
+`Error: ` prefix is what a piped or non-terminal run prints; an interactive terminal
+renders the same message with a glyph. Under `--json` this failure arrives **only** as
+one more object on stdout (see the `--json` note above) — there is no `Error:` line to
+match at all.
 
 **This matters if you are driving the CLI from a script or an agent loop.** Exit 1 from
 `--follow` partway through is the stream giving up, not proof that logging is

--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -100,14 +100,14 @@ the feature is not enabled for it. The CLI says so and polls instead, for the li
 the process:
 
 ```
-Realtime logs are not available for this app — falling back to polling (lines may lag ~20-30s).
+Warning: Realtime logs are not available for this app — falling back to polling (lines may lag ~20-30s).
 ```
 
 **The stream cannot be reached** — a transient failure that survived the retries. Same
 outcome, different message:
 
 ```
-Could not reach the realtime log stream — falling back to polling (lines may lag ~20-30s).
+Warning: Could not reach the realtime log stream — falling back to polling (lines may lag ~20-30s).
 ```
 
 Either way the command keeps working; the only difference is latency. On a legacy
@@ -121,14 +121,14 @@ cannot be re-established — repeated dead connections, or a typed end frame say
 tail is gone — `--follow` exits with an error rather than degrading:
 
 ```
-The realtime log stream stopped and could not be re-established
+Error: The realtime log stream stopped and could not be re-established
 ```
 
-It suggests starting a new tail (`base44 logs --follow`) or reading recent logs without
-streaming (`base44 logs`).
+It exits **1**, and suggests starting a new tail (`base44 logs --follow`) or reading
+recent logs without streaming (`base44 logs`).
 
-**This matters if you are driving the CLI from a script or an agent loop.** A non-zero
-exit from `--follow` partway through is the stream giving up, not proof that logging is
+**This matters if you are driving the CLI from a script or an agent loop.** Exit 1 from
+`--follow` partway through is the stream giving up, not proof that logging is
 broken and not a reason to change flags. Re-run the same command. Ordinary reconnects
 are invisible: the CLI reconnects on its own and only errors once it has run out of
 attempts.

--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -80,7 +80,13 @@ npx base44 logs --follow --function my-function
 - **`No logs found matching the filters.` is ambiguous.** It means one of: the run has not been ingested yet (~20-30s; wait and re-run — *do not* change flags), there is no function by that name, or a `--function` filter dropped unstamped rows from a legacy per-function deployment. It never means "the app is healthy".
 - `--follow` streams logs indefinitely (oldest to newest) instead of a single fetch; it's incompatible with `--since`, `--until` and `--order`. A stream that is lost and cannot be re-established ends the command with an error rather than dropping to polling. See [Following logs live](#following-logs-live).
 - Pass the global `--json` flag to emit each log entry as JSON instead of the human-readable format.
-- **With `--follow`, `--json` output is one JSON object per line, not one JSON document.** Parse it line by line as it arrives; there is no closing bracket, because a live tail never ends normally. If the stream is lost, the error arrives as one more object on its own line — `{"error": "The realtime log stream stopped and could not be re-established", "code": "API_ERROR", "hints": [...]}` — so a consumer that parses per line sees the failure as data rather than as a broken document.
+- **With `--follow`, `--json` output is one JSON object per line, not one JSON document.** Parse it line by line as it arrives; there is no closing bracket, because a live tail never ends normally. Nothing goes to stderr. If the stream is lost, the error arrives as one more object on its own line and the process exits 1:
+
+  ```json
+  {"error":"The realtime log stream stopped and could not be re-established","code":"API_ERROR","hints":[{"message":"Start a new live tail","command":"base44 logs --follow"},{"message":"Or read recent logs without streaming","command":"base44 logs"}]}
+  ```
+
+  Note `hints` holds **objects**, each with `message` and `command` — not strings. A consumer that parses per line sees the failure as data rather than as a broken document.
 
 ## Following logs live
 

--- a/skills/base44-troubleshooter/references/project-logs.md
+++ b/skills/base44-troubleshooter/references/project-logs.md
@@ -124,8 +124,10 @@ Both warnings go to **stderr**, never into the log output on stdout. They are sh
 above as they appear when output is **piped or otherwise not a terminal** — which is
 how an agent or a script sees them. In an interactive terminal the same text is
 rendered by the fancy logger with a coloured glyph instead of the literal
-`Warning: ` prefix, so match on the sentence, not on the prefix. Under `--json`
-there is no warning line at all.
+`Warning: ` prefix, so match on the sentence, not on the prefix. Under `--json` the
+warning still prints, on stderr — `--json` routes logs to stderr rather than silencing
+them, so a `--json` run gives you both: this warning on stderr, and log lines on
+stdout. (Only the lost-stream failure below is stdout-only.)
 
 ### A stream that dies mid-run ends the command — it does not quietly start polling
 


### PR DESCRIPTION
The first claims in this skill verified against a **running app** instead of against source.

`log-realtime` ran `base44@0.1.13` (the released artifact, fetched from `registry.npmjs.org`) in prod and against a mock rig, and reported what the terminal actually printed. Two things the docs had slightly wrong:

| | Page said | Actually printed |
|---|---|---|
| Both fallback lines | `Realtime logs are not available for this app — …` | `Warning: Realtime logs are not available for this app — …` |
| Lost stream | "a non-zero exit" | `Error: The realtime log stream stopped and could not be re-established`, exit code **1** |

The missing `Warning: ` / `Error: ` prefixes matter for this page's audience: an agent matching on a whole printed line would not have found either message.

**Evidence, all on 0.1.13:**
- refusal line printed live during a real flag-off window on `logs-probe`, and the poll fallback then fetched the bounded backlog
- transient line printed live against a 503 mock, which then genuinely dropped to the poll path
- dead-stream rig (SSE 200 then close, twice) → exit code 1, exact message, both hints
- happy path in prod: marker row ~2.7s after invoke